### PR TITLE
Display block name on non collapsed blocks in formwidget

### DIFF
--- a/formwidgets/blocks/partials/_repeater_item.php
+++ b/formwidgets/blocks/partials/_repeater_item.php
@@ -39,6 +39,7 @@
          data-control="formwidget"
          data-refresh-handler="<?= $this->getEventHandler('onRefresh') ?>"
          data-refresh-data="'_repeater_index': '<?= $indexValue ?>', '_repeater_group': '<?= $groupCode ?>'">
+        <h4><?= e(trans($itemTitle)); ?></h4>
         <?php foreach ($widget->getFields() as $field) : ?>
             <?= $widget->renderField($field) ?>
         <?php endforeach ?>


### PR DESCRIPTION
Now the user can see the blockname  on unfolded blocks to identify the right block to change content