### PR TITLE
Use better icons for default blocks

### DIFF
--- a/blocks/button_group.block
+++ b/blocks/button_group.block
@@ -1,6 +1,6 @@
 name: winter.blocks::lang.blocks.button_group.name
 description: winter.blocks::lang.blocks.button_group.description
-icon: icon-th-large
+icon: icon-object-group
 context: ["pages"]
 fields:
     buttons:

--- a/blocks/cards.block
+++ b/blocks/cards.block
@@ -1,6 +1,6 @@
 name: winter.blocks::lang.blocks.cards.name
 description: winter.blocks::lang.blocks.cards.description
-icon: icon-th-large
+icon: icon-grip
 context: ["pages"]
 fields:
     cards:

--- a/blocks/columns_two.block
+++ b/blocks/columns_two.block
@@ -1,6 +1,6 @@
 name: winter.blocks::lang.blocks.columns_two.name
 description: winter.blocks::lang.blocks.columns_two.description
-icon: icon-th-large
+icon: icon-table-columns
 context: ["pages"]
 fields:
     left:


### PR DESCRIPTION
Change blocks icons from the default one (icon-th-large) to a more explicit version.