### PR TITLE
Add block render functions

### DIFF
--- a/classes/Block.php
+++ b/classes/Block.php
@@ -35,34 +35,33 @@ class Block extends CmsCompoundObject
     }
 
     /**
-     * Renders a block content
+     * Renders the provided block
      */
     public static function render(string|array $block, array $data = []): string
     {
         if (is_array($block)) {
-            $data = array_merge($block, $data);
-
-            if (!array_key_exists('_group', $block)) {
-                throw new SystemException("The block definition must contain a `_group` key.");
-            }
-
-            $block = $block['_group'];
+            $data = $block;
+            $block = $data['_group'] ?? false;
+        }
+        
+        if (empty($block)) {
+            throw new SystemException("The block name was not provided");
         }
 
         return (new \Cms\Classes\Controller())->renderPartial($block . '.block', ['data' => $data]);
     }
 
     /**
-     * Renders a list of blocks
+     * Renders the provided blocks
      */
     public static function renderAll(array $blocks): string
     {
         $content = '';
         $controller = (new \Cms\Classes\Controller());
 
-        foreach ($blocks as $block) {
+        foreach ($blocks as $i => $block) {
             if (!array_key_exists('_group', $block)) {
-                throw new SystemException("The block definition must contain a `_group` key.");
+                throw new SystemException("The block definition at index $i must contain a `_group` key.");
             }
 
             $content .= $controller->renderPartial($block['_group'] . '.block', ['data' => $block]);

--- a/classes/Block.php
+++ b/classes/Block.php
@@ -48,7 +48,7 @@ class Block extends CmsCompoundObject
             throw new SystemException("The block name was not provided");
         }
 
-        return (new \Cms\Classes\Controller())->renderPartial($block . '.block', ['data' => $data]);
+        return (new Controller())->renderPartial($block . '.block', ['data' => $data]);
     }
 
     /**
@@ -57,7 +57,7 @@ class Block extends CmsCompoundObject
     public static function renderAll(array $blocks): string
     {
         $content = '';
-        $controller = (new \Cms\Classes\Controller());
+        $controller = (new Controller());
 
         foreach ($blocks as $i => $block) {
             if (!array_key_exists('_group', $block)) {

--- a/classes/Block.php
+++ b/classes/Block.php
@@ -35,6 +35,43 @@ class Block extends CmsCompoundObject
     }
 
     /**
+     * Renders a block content
+     */
+    public static function render(string|array $block, array $data = []): string
+    {
+        if (is_array($block)) {
+            $data = array_merge($block, $data);
+
+            if (!array_key_exists('_group', $block)) {
+                throw new SystemException("The block definition must contain a `_group` key.");
+            }
+
+            $block = $block['_group'];
+        }
+
+        return (new \Cms\Classes\Controller())->renderPartial($block . '.block', ['data' => $data]);
+    }
+
+    /**
+     * Renders a list of blocks
+     */
+    public static function renderAll(array $blocks): string
+    {
+        $content = '';
+        $controller = (new \Cms\Classes\Controller());
+
+        foreach ($blocks as $block) {
+            if (!array_key_exists('_group', $block)) {
+                throw new SystemException("The block definition must contain a `_group` key.");
+            }
+
+            $content .= $controller->renderPartial($block['_group'] . '.block', ['data' => $block]);
+        }
+
+        return $content;
+    }
+
+    /**
      * Returns name of a PHP class to us a parent for the PHP class created for the object's PHP section.
      */
     public function getCodeClassParent(): string


### PR DESCRIPTION
Adds the ability to render block contents from PHP.

```php
// Render all model's blocks
\Winter\Blocks\Classes\Block::renderAll($model->blocks);

// render a model block
\Winter\Blocks\Classes\Block::render($model->blocks[0]);

// Render a defined block
\Winter\Blocks\Classes\Block::render('title', [
    'content' => 'Lorem ipsum dolor sit amet.',
    'alignment_x' => 'left',
    'size' => 'h1',
]);
```

<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->