### PR TITLE
Add default values for `columns_two` block

### DIFF
--- a/blocks/columns_two.block
+++ b/blocks/columns_two.block
@@ -18,9 +18,9 @@ fields:
 ==
 <div class="grid grid-cols-1 md:grid-cols-2 md:mt-0 mt-5 gap-10 md:gap-4">
     <div>
-        {{ renderBlocks(left) }}
+        {{ renderBlocks(left | default([])) }}
     </div>
     <div>
-        {{ renderBlocks(right) }}
+        {{ renderBlocks(right | default([])) }}
     </div>
 </div>


### PR DESCRIPTION
Defines a default value for columns if they are not yet added to the block.  
This happens in case the two columns block is added to a page and then the page is saved without adding blocks on columns.

Using the `| default` filter avoid getting issue if the `cms.enableTwigStrictVariables` is set to true.

fix #20  