### PR TITLE
Allow callable for block config options

### DIFF
--- a/formwidgets/Blocks.php
+++ b/formwidgets/Blocks.php
@@ -337,9 +337,14 @@ class Blocks extends Repeater
                 'span',
             ]));
 
-            if (isset($defined['options']) && is_array($defined['options'])) {
-                foreach ($defined['options'] as $key => &$value) {
-                    $value = Lang::get($value);
+            if (isset($defined['options'])) {
+                if (is_array($defined['options'])) {
+                    foreach ($defined['options'] as $key => &$value) {
+                        $value = Lang::get($value);
+                    }
+                } elseif (is_callable($defined['options'])) {
+                    $callable = $defined['options'];
+                    $defined['options'] = $callable($this->formWidget, $this->formField);
                 }
             }
 


### PR DESCRIPTION
Allow options for block config to be [AJAX-derived options](https://wintercms.com/docs/v1.2/docs/backend/forms#ajax-derived-options).