### PR TITLE
Add support for removing a block(s) by key

### DIFF
--- a/classes/BlockManager.php
+++ b/classes/BlockManager.php
@@ -128,4 +128,20 @@ class BlockManager
     {
         return !!$this->getConfig($type);
     }
+
+    /**
+     * Remove a block by key
+     */
+    public function removeBlock(string|array $key): void
+    {
+        if (is_array($key)) {
+            foreach ($key as $k) {
+                $this->removeBlock($k);
+            }
+
+            return;
+        }
+
+        unset($this->blocks[$key]);
+    }
 }


### PR DESCRIPTION
This PR allows for removing blocks by calling `removeBlock` on the `BlockManager`.
```php
BlockManager::instance()->removeBlock('columns_two');
// or
BlockManager::instance()->removeBlock([
    'columns_two',
    'divider'
]);
```