### PR TITLE
Basic implementation that changes the Blocks formwidget to extend MLR…

### DIFF
--- a/blocks/button.block
+++ b/blocks/button.block
@@ -11,7 +11,7 @@ fields:
                 label:
                     label: winter.blocks::lang.fields.label
                     span: full
-                    type: text
+                    type: mltext
             tabs:
                 icons:
                     winter.blocks::lang.fields.actions: 'icon-arrow-pointer'

--- a/blocks/image.block
+++ b/blocks/image.block
@@ -4,13 +4,13 @@ icon: icon-picture-o
 tags: ["pages"]
 fields:
     image:
-        type: mediafinder
+        type: mlmediafinder
         span: full
         mode: image
     alt_text:
         label: winter.blocks::lang.blocks.image.alt_text
         span: full
-        type: text
+        type: mltext
 config:
     size:
         label: winter.blocks::lang.fields.size

--- a/blocks/plaintext.block
+++ b/blocks/plaintext.block
@@ -6,7 +6,7 @@ fields:
     content:
         placeholder: winter.blocks::lang.fields.content
         span: full
-        type: textarea
+        type: mltextarea
         size: small
 ==
 <p>

--- a/blocks/richtext.block
+++ b/blocks/richtext.block
@@ -6,7 +6,7 @@ fields:
     content:
         placeholder: winter.blocks::lang.fields.content
         span: full
-        type: richeditor
+        type: mlricheditor
 ==
 <div class="prose lg:prose-xl">
     {{ content | raw }}

--- a/blocks/title.block
+++ b/blocks/title.block
@@ -6,7 +6,7 @@ fields:
     content:
         placeholder: winter.blocks::lang.blocks.title.name
         span: full
-        type: text
+        type: mltext
 config:
     size:
         label: winter.blocks::lang.fields.size

--- a/blocks/video.block
+++ b/blocks/video.block
@@ -6,7 +6,7 @@ fields:
     video:
         label: winter.blocks::lang.blocks.video.name
         span: full
-        type: mediafinder
+        type: mlmediafinder
         mode: video
 ==
 {% if video %}

--- a/blocks/vimeo.block
+++ b/blocks/vimeo.block
@@ -5,7 +5,7 @@ tags: ["pages"]
 fields:
     vimeo_id:
         label: winter.blocks::lang.blocks.vimeo.vimeo_id
-        type: text
+        type: mltext
 ==
 {% if vimeo_id %}
     <iframe

--- a/blocks/youtube.block
+++ b/blocks/youtube.block
@@ -5,7 +5,7 @@ tags: ["pages"]
 fields:
     youtube_id:
         label: winter.blocks::lang.blocks.youtube.youtube_id
-        type: text
+        type: mltext
 ==
 {% if youtube_id %}
     <iframe

--- a/formwidgets/Blocks.php
+++ b/formwidgets/Blocks.php
@@ -402,7 +402,7 @@ class Blocks extends MLRepeater
                     // we reindex to fix item reordering index issues
                     // This will add the _group & _config data with the localized content
                     $values[$locale][$i++] = array_replace_recursive(
-                        json_decode(json_encode($this->formWidgets[$i - 1]->data), true),
+                        json_decode(json_encode($this->formWidgets[$index]->data), true),
                         $value
                     );
                 }


### PR DESCRIPTION
Basic implementation that changes the Blocks formwidget to extend MLRepeater and customizes the getLocaleSaveData to add the _group and _config to the save data. Also changes all blocks to use the Translate version (ml*).

This should be used alongside [my PR for the wintercms/wn-translate-plugin's wip-ml-repeater-fields draft PR branch](https://github.com/nmiyazaki-chapleau/wn-translate-plugin/tree/wip-ml-repeater-fields), at least until it gets merged into the [draft PR branch](https://github.com/wintercms/wn-translate-plugin/pull/76).

This implementation is basic and very very rough around the edges, but is a working proof of concept.
This POC forces users to use Translate. Ideally, there should be an easier way to override the `getLocaleSaveData` and extend the `MLRepeater` without forcing its use. A potential idea could be to just have an MLBlocks formwidget alongside the Blocks formwidget and add blocks that implement the ML versions.

I'm not a fan of using the formWidgets' `data` key as it is deprecated and should only be for backwards compatibility, but I did not find a simpler way for now.

The best implementation IMO would be to be able to add a `translatable` property to block fields which would make them use the ML version of their formwidget. I am not sure how the `translatable` property implementation in the `wip-ml-repeater-fields` branch is going, however.

I will gladly take any ideas or suggestions to improve this!