### PR TITLE
[FIX] Added fix for new files not being detected automatically

### DIFF
--- a/classes/BlocksDatasource.php
+++ b/classes/BlocksDatasource.php
@@ -15,7 +15,14 @@ class BlocksDatasource extends Datasource
     public function __construct()
     {
         $this->processor = new BlockProcessor();
-        $this->blocks = BlockManager::instance()->getRegisteredBlocks();
+        $this->blocks = array_merge(
+            // Get blocks registered via plugins
+            BlockManager::instance()->getRegisteredBlocks(),
+            // Get blocks existing in the autodatasource
+            BlockManager::instance()->getBlocks()->map(function ($block) {
+                return ['name' => $block->name, 'path' => $block->getFilePath()];
+            })->pluck('path', 'name')->toArray()
+        );
     }
 
     /**


### PR DESCRIPTION
This PR adds a fix to ensure that all blocks are considered when use generating the cache key.

The issue was caused by `BlocksDatasource::getPathsCacheKey()` not producing a cache key that included all file paths as some paths were being cached by said key. The `Block` `CmsCompoundObject` was able to detect the new files that were added but was unable to report them correctly as the hash used for caching was not being updated when the available paths were changed.

To fix this, during the `BlocksDatasource` init, I've added a check to ensure that both registered blocks and blocks detected by the datasource are correctly considered when generating the cache key.

This should resolve any issues of files not being available when they are available (i.e. adding a new file without clearing the cache).
