### PR TITLE
Fix add-item css selector

### DIFF
--- a/formwidgets/blocks/assets/js/blocks.js
+++ b/formwidgets/blocks/assets/js/blocks.js
@@ -184,7 +184,7 @@
 
         if (this.options.maxItems && this.options.maxItems > 0) {
             var repeatedItems = this.$el.find('> .field-repeater-items > .field-repeater-item').length,
-                $addItemBtn = this.$el.find('> .field-repeater-add-item')
+                $addItemBtn = this.$el.find('> .field-repeater-items > .field-repeater-add-item')
 
             $addItemBtn.toggle(repeatedItems < this.options.maxItems)
         }


### PR DESCRIPTION
The maxItems config was not working because the CSS selector was incorrect.