### PR TITLE
Return a Fluent instance for block config

### DIFF
--- a/classes/Block.php
+++ b/classes/Block.php
@@ -8,7 +8,8 @@ use Cms\Classes\CodeParser;
 use Cms\Classes\ComponentManager;
 use Cms\Classes\Controller;
 use Cms\Classes\PartialStack;
-use Lang;
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Fluent;
 use Winter\Storm\Exception\SystemException;
 
 /**
@@ -101,10 +102,12 @@ class Block extends CmsCompoundObject
             $partialData['data'] = $partialData;
 
             if (!empty($block['_config'])) {
-                $partialData['config'] = json_decode($block['_config']);
+                $config = json_decode($block['_config']);
             } else {
-                $partialData['config'] = static::getDefaultConfig($block['_group']);
+                $config = static::getDefaultConfig($block['_group']);
             }
+
+            $partialData['config'] = new Fluent($config);
 
             $content .= $controller->renderPartial($block['_group'] . '.block', $partialData);
         }


### PR DESCRIPTION
fix #23

Improve consistency between configuration data for blocks whose inspector has been opened or not.

> The Illuminate\Support\Fluent class is a useful data type. It allows for the construction of a data "container" similar to an array or instance of stdClass. However, the Fluent class makes it easier to make assumptions about the data the class instance contains.

## with arrays
```php
use Illuminate\Support\Fluent;

$data = [
     'a' => 1,
     'b' => 2,
];

dd($data['c']);      // Undefined array key "c"

$fluent = new Fluent($data);

dd($fluent['a']);      // 1  - array like attribute access
dd($fluent->b);       // 2 - object like property access 
dd($fluent['c']);     // null
dd($fluent->c);       // null

```
## with objects
```php
use Illuminate\Support\Fluent;

$data = (object) [
      'a' => 1,
      'b' => 2,
];

dd($data['a']);        // Cannot use object of type stdClass as array

$fluent = new Fluent($data);

dd($fluent['a']);      // 1  - array like attribute access
dd($fluent->b);       // 2 - object like property access 
dd($fluent['c']);     // null
dd($fluent->c);       // null
```

⚠ If a key is not present, a null value will be return (default behavior).