### PR TITLE
Blocks: Always send a value in the Form data

### DIFF
--- a/formwidgets/Blocks.php
+++ b/formwidgets/Blocks.php
@@ -72,7 +72,7 @@ class Blocks extends Repeater
     protected function processSaveValue($value)
     {
         if (!is_array($value) || !$value) {
-            return $value;
+            return null;
         }
 
         $count = count($value);

--- a/formwidgets/blocks/partials/_block.php
+++ b/formwidgets/blocks/partials/_block.php
@@ -12,6 +12,10 @@
     data-sortable-handle=".<?= $this->getId('items') ?>-handle"
     <?php endif; ?>
 >
+    <?php if (!$this->previewMode): ?>
+        <input type="hidden" name="<?= $this->getFieldName(); ?>">
+    <?php endif ?>
+
     <ul id="<?= $this->getId('items') ?>" class="field-repeater-items">
         <?php foreach ($formWidgets as $index => $widget) : ?>
             <?= $this->makePartial('block_item', [


### PR DESCRIPTION
Replicate fix that was done for repeater formwidget.

This also prevents an infinite loop when calling renderBlocks() on empty blocks.

ref. https://github.com/wintercms/winter/pull/1300