### PR TITLE
Fix: Block config popover not closing in CMS page editor

### DIFF
--- a/formwidgets/blocks/partials/_block_item.php
+++ b/formwidgets/blocks/partials/_block_item.php
@@ -56,7 +56,7 @@ $itemIcon = $this->getGroupIcon($groupCode);
             data-inspector-offset-x="-15"
         >
             <i class="icon-cog"></i>
-            <input type="hidden" data-inspector-values name="<?= $widget->arrayName ?>[_config]" value="<?= e($groupConfig ?? '') ?>" />
+            <input type="hidden" data-inspector-values name="<?= $widget->arrayName ?>[_config]" value="<?= e($groupConfig ?: '{}') ?>" />
         </a>
     <?php endif ?>
 


### PR DESCRIPTION
## Problem

When using the blocks field widget inside a `Cms\Page`, clicking the block config button
(`<a class="block-config">`) opens an inspector popover. Closing the popover threw a
JavaScript exception and left it stuck open:

```
Uncaught SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at CmsPage.onInspectorHiding (winter.cmspage.js:476:27)
```

## Root Cause

`winter.cmspage.js` registers an `onInspectorHiding` handler on **all** `[data-inspectable]`
elements in the CMS editor. This handler was written for CMS component inspectors and
unconditionally calls `JSON.parse` on the value of `[data-inspector-values]`:

```js
values = JSON.parse($('[data-inspector-values]', element).val())
```

The blocks widget also marks its config button as `data-inspectable` and stores config
in a `[data-inspector-values]` hidden input. For newly added blocks that have never been
configured, `$groupConfig` is `null`, so the input rendered with `value=""`. Parsing an
empty string throws the exception, which interrupted the hiding event and prevented the
popover from closing.

This issue only manifests in the CMS page editor because `onInspectorHiding` is
registered exclusively by `winter.cmspage.js`.

## Fix

In `_block_item.php`, default `$groupConfig` to `'{}'` (valid empty JSON object) instead
of `''` (empty string):

```php
// Before
value="<?= e($groupConfig ?? '') ?>"

// After
value="<?= e($groupConfig ?: '{}') ?>"
```

This ensures `JSON.parse` always receives valid JSON regardless of whether the block has
been configured.
