### PR TITLE
Add collapsible sections support to block section fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## Unreleased
+
+### Collapsible sections
+- `.block` `type: section` fields support a `collapsible: true` shorthand, with
+  `collapsed: true|false` controlling the initial state.
+- Handled via the `data-block-collapsible` attribute and an inline bootstrap in
+  the block widget partial, independent of core's collapsible-section JS. This
+  fixes the core behaviour where adding an item to a repeater nested inside a
+  section re-collapsed it and double-bound its click handler (causing the
+  "Add item" stall).
+- **Open/closed state now persists** per section across page reloads
+  (`localStorage`, keyed by field name and scoped per widget instance).
+
+### Tests
+- `BlocksTest`: `collapsible`/`collapsed` shorthand translation to
+  `data-block-collapsible` / `data-block-collapsible-open`, and that non-section
+  / plain-section fields are left untouched.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,35 @@ config:
 </{{ config.size }}>
 ```
 
+## Collapsible Sections
+
+Block fields that use `type: section` can be made collapsible directly in the block YAML.
+
+```yaml
+fields:
+    section_advanced:
+        label: Advanced settings
+        type: section
+        collapsible: true        # makes the section click-to-collapse
+        collapsed: true          # initial state: true = start collapsed (default), false = start open
+    some_field:
+        label: Some field
+        type: text
+```
+
+**Shorthand rules:**
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `collapsible` | bool | — | Set to `true` to enable the collapse toggle |
+| `collapsed` | bool | `true` | Initial state. `false` = section starts open |
+
+When `collapsible: true` is set, the section header becomes a click target. Sections start collapsed by default; set `collapsed: false` to have the section open on first load. Each section's open/closed state is **remembered across page reloads** (stored in `localStorage`, keyed by field name and scoped per widget instance), so the editor returns to the state you left it in.
+
+> **Note:** Collapsible behaviour is handled via the `data-block-collapsible` attribute, bootstrapped inline in the block widget partial (`formwidgets/blocks/partials/_block.php`), independent of WinterCMS's core collapsible-section JS. This is deliberate: core re-collapses and re-binds every section on each form-widget init — including when a nested repeater adds an item — which broke manually-opened sections and stalled repeater "Add item" clicks. Owning the behaviour avoids that entirely, so collapsible sections work correctly even with repeater fields nested inside them.
+
+---
+
 ## Using the `blocks` FormWidget
 
 In order to provide an interface for managing block-based content, this plugin provides the `blocks` FormWidget. This widget can be used in the backend as a form field to manage blocks.

--- a/formwidgets/Blocks.php
+++ b/formwidgets/Blocks.php
@@ -53,6 +53,9 @@ class Blocks extends Repeater
     {
         $this->addCss('css/blocks.css', 'Winter.Blocks');
         $this->addJs('js/blocks.js', 'Winter.Blocks');
+        // Collapsible-section behaviour is bootstrapped inline in the block
+        // widget partial (formwidgets/blocks/partials/_block.php) so it loads
+        // reliably regardless of asset-path resolution or the asset combiner.
     }
 
     /**
@@ -203,12 +206,12 @@ class Blocks extends Repeater
             }
 
             $definitions[$code] = [
-                'code' => $code,
-                'name' => array_get($config, 'name'),
-                'icon' => array_get($config, 'icon', 'icon-square-o'),
-                'description' => array_get($config, 'description'),
-                'fields' => array_get($config, 'fields'),
-                'config' => array_get($config, 'config', null),
+                'code'          => $code,
+                'name'          => array_get($config, 'name'),
+                'icon'          => array_get($config, 'icon', 'icon-square-o'),
+                'description'   => array_get($config, 'description'),
+                'fields'        => $this->normalizeBlockFields((array) array_get($config, 'fields', [])),
+                'config'        => array_get($config, 'config', null),
             ];
         }
 
@@ -217,6 +220,50 @@ class Blocks extends Repeater
 
         $this->groupDefinitions = $definitions;
         $this->useGroups = true;
+    }
+
+    /**
+     * Translates block YAML shorthands before the fields are handed to the form widget.
+     *
+     * Supported shorthands on `type: section` fields:
+     *   collapsible: true          — makes the section click-to-collapse
+     *   collapsed: true|false      — initial state (true = start collapsed, false = start open)
+     *                                defaults to true when collapsible is set
+     */
+    protected function normalizeBlockFields(array $fields): array
+    {
+        foreach ($fields as &$field) {
+            if (($field['type'] ?? '') !== 'section') {
+                continue;
+            }
+
+            if (!array_key_exists('collapsible', $field)) {
+                continue;
+            }
+
+            if ($field['collapsible']) {
+                $startCollapsed = $field['collapsed'] ?? true;
+
+                // Use our own data attribute (NOT data-field-collapsible) so the
+                // core form widget's bindCollapsibleSections() never touches these
+                // sections. Core re-runs that on every FormWidget init — including
+                // when a nested repeater adds an item — which would re-collapse and
+                // double-bind handlers on sections the user manually opened. We own
+                // the behaviour entirely in the inline bootstrap instead.
+                $field['containerAttributes'] = array_merge(
+                    $field['containerAttributes'] ?? [],
+                    ['data-block-collapsible' => 1]
+                );
+
+                if (!$startCollapsed) {
+                    $field['containerAttributes']['data-block-collapsible-open'] = 1;
+                }
+            }
+
+            unset($field['collapsible'], $field['collapsed']);
+        }
+
+        return $fields;
     }
 
     /**

--- a/formwidgets/blocks/partials/_block.php
+++ b/formwidgets/blocks/partials/_block.php
@@ -5,6 +5,7 @@
     <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
     <?= $style ? 'data-style="'.$style.'"' : '' ?>
     data-mode="<?= $mode ?>"
+    data-widget-id="<?= $this->getId() ?>"
     <?php if ($mode === 'grid'): ?> data-columns="<?= $columns ?>" <?php endif ?>
     <?php if ($sortable) : ?>
     data-sortable="true"
@@ -84,5 +85,111 @@
                 </div>
             </div>
         </div>
+    </script>
+
+    <?php
+    /*
+     * Inline bootstrap for collapsible sections (persisting open/closed state
+     * per section). Loaded inline (rather than only via addJs) so it is
+     * guaranteed to reach the page regardless of widget asset-path resolution
+     * or the asset combiner. A global guard ensures the handlers are
+     * registered only once even when several block widgets render on the
+     * same page.
+     *
+     * Collapse behaviour lives on the data-block-collapsible attribute, which
+     * the core form widget's bindCollapsibleSections() never selects — so
+     * core cannot re-collapse or double-bind these sections when a nested
+     * repeater adds an item.
+     */
+    ?>
+    <script>
+    (function () {
+        if (window.__blockCollapsibleInit) { return; }
+        window.__blockCollapsibleInit = true;
+
+        var READY = 'block-collapsible-ready';
+        var COLLAPSE_PREFIX = 'wnBlocksCollapse:';
+
+        function lsGet(key) {
+            try { return window.localStorage.getItem(key); } catch (e) { return null; }
+        }
+        function lsSet(key, val) {
+            try { window.localStorage.setItem(key, val); } catch (e) {}
+        }
+
+        function followingFields(section) {
+            var els = [], el = section.nextElementSibling;
+            while (el && !el.classList.contains('section-field')) {
+                els.push(el);
+                el = el.nextElementSibling;
+            }
+            return els;
+        }
+
+        function setCollapsed(section, collapsed) {
+            section.classList.toggle('collapsed', collapsed);
+            followingFields(section).forEach(function (el) {
+                el.style.display = collapsed ? 'none' : '';
+            });
+        }
+
+        // Scoped to data-widget-id so sections with the same field name in
+        // different block widgets on the same page don't share state.
+        function storageKey(section) {
+            var name = section.getAttribute('data-field-name') || '';
+            if (!name) { return null; }
+            var fieldBlocks = section.closest('.field-blocks');
+            var widgetId = fieldBlocks ? (fieldBlocks.getAttribute('data-widget-id') || '') : '';
+            return COLLAPSE_PREFIX + (widgetId ? widgetId + ':' : '') + name;
+        }
+
+        function initSections() {
+            document.querySelectorAll(
+                '.section-field[data-block-collapsible]:not(.' + READY + ')'
+            ).forEach(function (section) {
+                section.classList.add(READY);
+                var header = section.querySelector('.field-section');
+                if (header) { header.classList.add('is-collapsible'); }
+
+                // Restore persisted state if present, else fall back to config default.
+                var key = storageKey(section);
+                var stored = key ? lsGet(key) : null;
+                var collapsed = stored !== null
+                    ? stored === '1'
+                    : !section.hasAttribute('data-block-collapsible-open');
+                setCollapsed(section, collapsed);
+            });
+        }
+
+        document.addEventListener('click', function (e) {
+            var section = e.target.closest('.section-field[data-block-collapsible]');
+            if (!section) { return; }
+            var collapsed = !section.classList.contains('collapsed');
+            setCollapsed(section, collapsed);
+            var key = storageKey(section);
+            if (key) { lsSet(key, collapsed ? '1' : '0'); }
+        });
+
+        initSections();
+
+        var scheduled = false;
+        var observer = new MutationObserver(function (mutations) {
+            if (!mutations.some(function (m) { return m.addedNodes.length > 0; })) { return; }
+            if (scheduled) { return; }
+            scheduled = true;
+            setTimeout(function () {
+                scheduled = false;
+                initSections();
+            }, 0);
+        });
+        function startObserving() {
+            if (document.body) {
+                observer.observe(document.body, { childList: true, subtree: true });
+            } else {
+                document.addEventListener('DOMContentLoaded', startObserving);
+            }
+        }
+        startObserving();
+    })();
     </script>
 </div>

--- a/tests/formwidgets/BlocksTest.php
+++ b/tests/formwidgets/BlocksTest.php
@@ -63,6 +63,108 @@ class BlocksTest extends PluginTestCase
         $this->assertInstanceOf(Blocks::class, $this->createTestFormWidget());
     }
 
+    /**
+     * Invokes the protected normalizeBlockFields() on a widget instance.
+     */
+    protected function normalizeBlockFields(Blocks $widget, array $fields): array
+    {
+        $method = new \ReflectionMethod(Blocks::class, 'normalizeBlockFields');
+        $method->setAccessible(true);
+
+        return $method->invoke($widget, $fields);
+    }
+
+    /**
+     * @testdox translates collapsible: true into the data-block-collapsible attribute
+     */
+    public function testCollapsibleShorthandAddsAttribute()
+    {
+        $widget = $this->createTestFormWidget();
+
+        $result = $this->normalizeBlockFields($widget, [
+            'section_advanced' => [
+                'type' => 'section',
+                'label' => 'Advanced',
+                'collapsible' => true,
+            ],
+        ]);
+
+        $field = $result['section_advanced'];
+
+        $this->assertArrayHasKey('data-block-collapsible', $field['containerAttributes']);
+        // Defaults to collapsed: no "open" marker.
+        $this->assertArrayNotHasKey('data-block-collapsible-open', $field['containerAttributes']);
+        // Shorthand keys are removed once translated.
+        $this->assertArrayNotHasKey('collapsible', $field);
+        $this->assertArrayNotHasKey('collapsed', $field);
+    }
+
+    /**
+     * @testdox marks a section as initially open when collapsed: false
+     */
+    public function testCollapsedFalseAddsOpenAttribute()
+    {
+        $widget = $this->createTestFormWidget();
+
+        $result = $this->normalizeBlockFields($widget, [
+            'section_open' => [
+                'type' => 'section',
+                'label' => 'Open',
+                'collapsible' => true,
+                'collapsed' => false,
+            ],
+        ]);
+
+        $attrs = $result['section_open']['containerAttributes'];
+
+        $this->assertArrayHasKey('data-block-collapsible', $attrs);
+        $this->assertArrayHasKey('data-block-collapsible-open', $attrs);
+    }
+
+    /**
+     * @testdox does not add the open marker when collapsed: true
+     */
+    public function testCollapsedTrueOmitsOpenAttribute()
+    {
+        $widget = $this->createTestFormWidget();
+
+        $result = $this->normalizeBlockFields($widget, [
+            'section_closed' => [
+                'type' => 'section',
+                'label' => 'Closed',
+                'collapsible' => true,
+                'collapsed' => true,
+            ],
+        ]);
+
+        $attrs = $result['section_closed']['containerAttributes'];
+
+        $this->assertArrayHasKey('data-block-collapsible', $attrs);
+        $this->assertArrayNotHasKey('data-block-collapsible-open', $attrs);
+    }
+
+    /**
+     * @testdox leaves non-section fields and sections without the shorthand untouched
+     */
+    public function testNonCollapsibleFieldsUntouched()
+    {
+        $widget = $this->createTestFormWidget();
+
+        $result = $this->normalizeBlockFields($widget, [
+            'title' => [
+                'type' => 'text',
+                'label' => 'Title',
+            ],
+            'plain_section' => [
+                'type' => 'section',
+                'label' => 'Plain',
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('containerAttributes', $result['title']);
+        $this->assertArrayNotHasKey('containerAttributes', $result['plain_section']);
+    }
+
     public function testCanLimitAvailableBlocksByTag()
     {
         BlockManager::instance()->registerBlock('container', $this->fixturePath . 'container.block');

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,2 +1,4 @@
 '1.0.0':
     - 'First version of Winter.Blocks'
+'1.1.0':
+    - 'Collapsible sections with persisted state'


### PR DESCRIPTION
Split out of #68 (closed in favor of smaller, focused PRs).

## Summary
- `.block` `type: section` fields support a `collapsible: true` shorthand, with `collapsed: true|false` controlling the initial state.
- Handled via a `data-block-collapsible` attribute and an inline bootstrap in the block widget partial, independent of core's collapsible-section JS — this avoids core re-collapsing and re-binding every section on each form-widget init (which broke manually-opened sections and stalled repeater "Add item" clicks when a section had a repeater nested inside it).
- Open/closed state persists per section across page reloads (`localStorage`, keyed by field name).

See the README section "Collapsible Sections" for usage.

## Test plan
- [x] New tests in `tests/formwidgets/BlocksTest.php` covering the collapsible markup
- [x] Full plugin test suite passes (`php artisan winter:test -p Winter.Blocks`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collapsible sections for block widgets using simple field configuration.
  * Section open/closed state now persists across page reloads.
  * Supports setting the initial expanded or collapsed state.

* **Bug Fixes**
  * Improved reliability when adding nested repeater items within collapsible sections.
  * Prevented duplicate click handling and related “Add item” stalls.

* **Documentation**
  * Added configuration examples and guidance for collapsible sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->