### PR TITLE
Add shared field includes and recently-used blocks palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## Unreleased
+
+### Shared field includes
+- `.block` definitions may declare a top-level `include:` (string or list) to
+  merge `fields` and `config` from external plain-YAML files.
+- Included definitions form the base; the block's own definitions override on
+  collision. Paths resolve via `File::symbolizePath()` (`$/`, `~/`, `#/`).
+- **Nested includes** are resolved recursively, guarded against circular
+  references.
+- A **schema guard** logs a warning when an include would redefine a field with
+  a different `type`.
+- Missing include files are skipped and logged as a warning.
+
+### Editor UX
+- **Recently used blocks** are pinned to the top of the "add block" palette
+  (tracked in `localStorage`, most-recent first).
+
+### Tests
+- `BlockManagerTest`: include merging, block-overrides-include precedence,
+  nested includes, circular-include guard, missing-file skip, multiple includes,
+  and the no-include no-op.
+- Fixtures under `tests/fixtures/blocks/includes/`.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,73 @@ config:
 </{{ config.size }}>
 ```
 
+## Including shared field definitions
+
+To avoid repeating the same fields (or sections) across many blocks, a block can pull them in from one or more external YAML files via the top-level `include` key.
+
+```yaml
+name: Article
+description: An article block
+icon: icon-newspaper
+
+include: $/myauthor/myplugin/blocks/_seo.yaml
+
+fields:
+    title:
+        label: Title
+        type: text
+==
+<article>{{ title }}</article>
+```
+
+`_seo.yaml` is a plain YAML file (no `==` markup, no block metadata) containing any of `fields` or `config`:
+
+```yaml
+# blocks/_seo.yaml
+fields:
+    meta_title:
+        label: Meta title
+        type: text
+    meta_description:
+        label: Meta description
+        type: textarea
+```
+
+**Multiple includes** — pass a list; they are merged in order:
+
+```yaml
+include:
+    - $/myauthor/myplugin/blocks/_seo.yaml
+    - ~/app/blocks/_tracking.yaml
+```
+
+**Merge rules:**
+
+| | |
+|---|---|
+| Merged keys | `fields`, `config` |
+| Precedence | Included files form the base; the block's own definitions **override** on key collision |
+| Order | Multiple includes merge top-to-bottom (later files override earlier ones, the block still wins overall) |
+| Nested includes | An included file may itself declare `include:` — resolved recursively, with a circular-reference guard |
+| Type guard | Redefining a field with a different `type` than the include logs a warning |
+| Missing files | Skipped, and logged as a warning |
+
+**Path resolution** uses the standard Winter path symbols via `File::symbolizePath()`:
+
+| Symbol | Resolves to |
+|---|---|
+| `$/author/plugin/...` | `plugins/author/plugin/...` |
+| `~/...` | application root |
+| `#/...` | `storage/app/...` |
+
+---
+
+## Recently used blocks
+
+When adding a block from the palette, the blocks you use most recently are pinned to the top of the list (tracked per browser in `localStorage`, most-recent first). This speeds up repetitive content building where the same few block types are added over and over. No configuration is required.
+
+---
+
 ## Using the `blocks` FormWidget
 
 In order to provide an interface for managing block-based content, this plugin provides the `blocks` FormWidget. This widget can be used in the backend as a form field to manage blocks.

--- a/classes/BlockManager.php
+++ b/classes/BlockManager.php
@@ -7,6 +7,8 @@ use Cms\Classes\Controller;
 use Cms\Classes\Theme;
 use Event;
 use File;
+use Log;
+use Yaml;
 use System\Classes\PluginManager;
 use Winter\Storm\Support\Traits\Singleton;
 use Winter\Storm\Support\Str;
@@ -98,7 +100,7 @@ class BlockManager
                 }
             }
 
-            $configs[pathinfo($block['fileName'])['filename']] = array_except(
+            $config = array_except(
                 $block->getAttributes(),
                 [
                     'fileName',
@@ -108,9 +110,126 @@ class BlockManager
                     'code',
                 ]
             );
+
+            $config = $this->resolveIncludes($config);
+
+            $configs[pathinfo($block['fileName'])['filename']] = $config;
         }
 
         return $configs;
+    }
+
+    /**
+     * Resolves an `include` directive in a block definition by merging field
+     * definitions from one or more external YAML files.
+     *
+     * A block may declare:
+     *
+     *     include: $/author/plugin/blocks/_shared.yaml
+     *     # or
+     *     include:
+     *         - $/author/plugin/blocks/_seo.yaml
+     *         - ~/app/blocks/_tracking.yaml
+     *
+     * Each included file is a plain YAML file that may contain any of the keys
+     * `fields` and `config`. Included definitions are
+     * merged in order and act as a base; the block's own definitions take
+     * precedence on key collisions.
+     *
+     * Included files may themselves declare an `include` key — nested includes
+     * are resolved recursively, guarded against circular references.
+     *
+     * Paths are resolved with File::symbolizePath(), so the usual Winter symbols
+     * are supported ($ = plugins, ~ = app, # = app/storage/...).
+     *
+     * @param string[] $visited Canonical paths already being resolved (cycle guard).
+     */
+    protected function resolveIncludes(array $config, array $visited = []): array
+    {
+        if (empty($config['include'])) {
+            unset($config['include']);
+            return $config;
+        }
+
+        $paths = (array) $config['include'];
+        unset($config['include']);
+
+        $mergeKeys = ['fields', 'config'];
+
+        // Capture the block's own definitions before the loop so that each
+        // include sees the original block values, not a previously merged result.
+        // This ensures the block always wins on collision regardless of include order,
+        // and that later includes correctly override earlier ones (not the merged state).
+        $ownByKey = [];
+        foreach ($mergeKeys as $key) {
+            $ownByKey[$key] = (isset($config[$key]) && is_array($config[$key])) ? $config[$key] : [];
+        }
+
+        foreach ($paths as $path) {
+            if (!is_string($path) || $path === '') {
+                continue;
+            }
+
+            $realPath = File::symbolizePath($path);
+            if (!$realPath || !File::exists($realPath)) {
+                Log::warning("Winter.Blocks: included file not found: {$path}");
+                continue;
+            }
+
+            $canonical = PathResolver::standardize($realPath);
+            if (in_array($canonical, $visited, true)) {
+                Log::warning("Winter.Blocks: circular include detected, skipping: {$path}");
+                continue;
+            }
+
+            $included = Yaml::parse(File::get($realPath));
+            if (!is_array($included)) {
+                continue;
+            }
+
+            // Resolve nested includes first so they form the deepest base layer.
+            $included = $this->resolveIncludes($included, array_merge($visited, [$canonical]));
+
+            foreach ($mergeKeys as $key) {
+                if (!isset($included[$key]) || !is_array($included[$key])) {
+                    continue;
+                }
+
+                $own = $ownByKey[$key];
+
+                // Warn when a field is redefined with a different type.
+                $this->warnOnTypeCollisions($key, $included[$key], $own);
+
+                // Included definitions form the base; the block's own definitions always win.
+                // Later includes override earlier ones; the block overrides all.
+                $config[$key] = array_replace_recursive($included[$key], $config[$key] ?? [], $own);
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * Logs a warning when merging an include would redefine a field with a
+     * different `type`, which is almost always a mistake.
+     */
+    protected function warnOnTypeCollisions(string $key, array $included, array $own): void
+    {
+        foreach ($included as $name => $def) {
+            if (!isset($own[$name]) || !is_array($def) || !is_array($own[$name])) {
+                continue;
+            }
+
+            $includedType = $def['type'] ?? null;
+            $ownType = $own[$name]['type'] ?? null;
+
+            if ($includedType && $ownType && $includedType !== $ownType) {
+                Log::warning(
+                    "Winter.Blocks: field '{$name}' redefined with a different type " .
+                    "('{$ownType}' overrides included '{$includedType}') in '{$key}'."
+                );
+            }
+        }
     }
 
     /**

--- a/classes/BlockManager.php
+++ b/classes/BlockManager.php
@@ -165,6 +165,15 @@ class BlockManager
             $ownByKey[$key] = (isset($config[$key]) && is_array($config[$key])) ? $config[$key] : [];
         }
 
+        // Accumulates the merged result of the includes only (own definitions
+        // excluded), so that each new include can freely override the previous
+        // includes without the block's own values getting mixed in as a
+        // tie-breaker. The block's own values are applied once, after the loop.
+        $includedByKey = [];
+        foreach ($mergeKeys as $key) {
+            $includedByKey[$key] = [];
+        }
+
         foreach ($paths as $path) {
             if (!is_string($path) || $path === '') {
                 continue;
@@ -195,15 +204,24 @@ class BlockManager
                     continue;
                 }
 
-                $own = $ownByKey[$key];
-
                 // Warn when a field is redefined with a different type.
-                $this->warnOnTypeCollisions($key, $included[$key], $own);
+                $this->warnOnTypeCollisions($key, $included[$key], $ownByKey[$key]);
 
-                // Included definitions form the base; the block's own definitions always win.
-                // Later includes override earlier ones; the block overrides all.
-                $config[$key] = array_replace_recursive($included[$key], $config[$key] ?? [], $own);
+                // Later includes override earlier ones. Kept separate from
+                // $ownByKey so the block's own values can't act as a
+                // tie-breaker between includes (that previously made the
+                // first include always win instead of the last one).
+                $includedByKey[$key] = array_replace_recursive($includedByKey[$key], $included[$key]);
             }
+        }
+
+        foreach ($mergeKeys as $key) {
+            if (empty($includedByKey[$key])) {
+                continue;
+            }
+
+            // Merged includes form the base; the block's own definitions always win.
+            $config[$key] = array_replace_recursive($includedByKey[$key], $ownByKey[$key]);
         }
 
         return $config;

--- a/formwidgets/blocks/partials/_block.php
+++ b/formwidgets/blocks/partials/_block.php
@@ -69,6 +69,7 @@
                                 <a
                                     href="javascript:;"
                                     data-repeater-add
+                                    data-block-code="<?= $item['code'] ?>"
                                     data-request="<?= $this->getEventHandler('onAddItem') ?>"
                                     data-request-data="_repeater_group: '<?= $item['code'] ?>'">
                                     <i class="<?= $item['icon'] ?>"></i>
@@ -84,5 +85,95 @@
                 </div>
             </div>
         </div>
+    </script>
+
+    <?php
+    /*
+     * Inline bootstrap for "recently used blocks": pins the most recently added
+     * block types to the top of the "add block" palette. Loaded inline (rather
+     * than only via addJs) so it is guaranteed to reach the page regardless of
+     * widget asset-path resolution or the asset combiner. A global guard ensures
+     * the handlers are registered only once even when several block widgets
+     * render on the same page.
+     */
+    ?>
+    <script>
+    (function () {
+        if (window.__blockRecentInit) { return; }
+        window.__blockRecentInit = true;
+
+        var RECENT_KEY = 'wnBlocksRecent';
+        var RECENT_MAX = 6;
+
+        function lsGet(key) {
+            try { return window.localStorage.getItem(key); } catch (e) { return null; }
+        }
+        function lsSet(key, val) {
+            try { window.localStorage.setItem(key, val); } catch (e) {}
+        }
+
+        function getRecent() {
+            try {
+                var raw = lsGet(RECENT_KEY);
+                var arr = raw ? JSON.parse(raw) : [];
+                return Array.isArray(arr) ? arr : [];
+            } catch (e) { return []; }
+        }
+
+        function pushRecent(code) {
+            if (!code) { return; }
+            var arr = getRecent().filter(function (c) { return c !== code; });
+            arr.unshift(code);
+            arr = arr.slice(0, RECENT_MAX);
+            lsSet(RECENT_KEY, JSON.stringify(arr));
+        }
+
+        // Record a block as recently used whenever one is added from the palette.
+        document.addEventListener('click', function (e) {
+            var a = e.target.closest('[data-block-code]');
+            if (!a) { return; }
+            pushRecent(a.getAttribute('data-block-code'));
+        });
+
+        // When a palette grid appears, move recently used blocks to the front.
+        // Reordering (rather than cloning) avoids duplicates and styling issues
+        // and degrades gracefully if the markup differs.
+        function applyRecent() {
+            document.querySelectorAll('.blocks-group-grid:not([data-recent-processed])')
+                .forEach(function (grid) {
+                    grid.setAttribute('data-recent-processed', '1');
+                    var recent = getRecent();
+                    // Reverse so the most recent ends up first after successive prepends.
+                    recent.slice().reverse().forEach(function (code) {
+                        var link = grid.querySelector('a[data-block-code="' + code + '"]');
+                        var item = link && link.closest('.blocks-group-item');
+                        if (item && item.parentNode === grid) {
+                            grid.insertBefore(item, grid.firstChild);
+                        }
+                    });
+                });
+        }
+
+        applyRecent();
+
+        var scheduled = false;
+        var observer = new MutationObserver(function (mutations) {
+            if (!mutations.some(function (m) { return m.addedNodes.length > 0; })) { return; }
+            if (scheduled) { return; }
+            scheduled = true;
+            setTimeout(function () {
+                scheduled = false;
+                applyRecent();
+            }, 0);
+        });
+        function startObserving() {
+            if (document.body) {
+                observer.observe(document.body, { childList: true, subtree: true });
+            } else {
+                document.addEventListener('DOMContentLoaded', startObserving);
+            }
+        }
+        startObserving();
+    })();
     </script>
 </div>

--- a/tests/classes/BlockManagerTest.php
+++ b/tests/classes/BlockManagerTest.php
@@ -35,6 +35,151 @@ class BlockManagerTest extends PluginTestCase
         $this->pluginPath = dirname(dirname(__DIR__)) . '/blocks/';
     }
 
+    /**
+     * Invokes the protected resolveIncludes() with the given block config.
+     */
+    protected function resolveIncludes(array $config): array
+    {
+        $method = new \ReflectionMethod(BlockManager::class, 'resolveIncludes');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->manager, $config);
+    }
+
+    protected function includePath(string $file): string
+    {
+        return '$/winter/blocks/tests/fixtures/blocks/includes/' . $file;
+    }
+
+    /**
+     * @testdox merges fields and config from an included file
+     */
+    public function testIncludeMergesDefinitions()
+    {
+        $result = $this->resolveIncludes([
+            'include' => $this->includePath('_shared.yaml'),
+            'fields' => [
+                'title' => ['label' => 'Title', 'type' => 'text'],
+            ],
+        ]);
+
+        // The include key itself is stripped.
+        $this->assertArrayNotHasKey('include', $result);
+
+        // Fields from both the include and the block are present.
+        $this->assertArrayHasKey('shared_field', $result['fields']);
+        $this->assertArrayHasKey('title', $result['fields']);
+
+        // config from the include is merged in too.
+        $this->assertArrayHasKey('shared_config', $result['config']);
+
+        // tabs are not a supported merge key.
+        $this->assertArrayNotHasKey('tabs', $result);
+    }
+
+    /**
+     * @testdox lets the block's own definitions override the include on collision
+     */
+    public function testBlockOverridesInclude()
+    {
+        $result = $this->resolveIncludes([
+            'include' => $this->includePath('_shared.yaml'),
+            'fields' => [
+                'overridden' => ['label' => 'From block', 'type' => 'textarea'],
+            ],
+        ]);
+
+        $this->assertEquals('From block', $result['fields']['overridden']['label']);
+        $this->assertEquals('textarea', $result['fields']['overridden']['type']);
+    }
+
+    /**
+     * @testdox resolves nested includes recursively
+     */
+    public function testNestedIncludesAreResolved()
+    {
+        $result = $this->resolveIncludes([
+            'include' => $this->includePath('_with_nested.yaml'),
+            'fields' => [
+                'own_field' => ['label' => 'Own', 'type' => 'text'],
+            ],
+        ]);
+
+        // base_field (deepest), mid_field (middle), own_field (block) all present.
+        $this->assertArrayHasKey('base_field', $result['fields']);
+        $this->assertArrayHasKey('mid_field', $result['fields']);
+        $this->assertArrayHasKey('own_field', $result['fields']);
+    }
+
+    /**
+     * @testdox does not loop on circular includes and still merges what it can
+     */
+    public function testCircularIncludeIsGuarded()
+    {
+        $result = $this->resolveIncludes([
+            'include' => $this->includePath('_cycle_a.yaml'),
+            'fields' => [
+                'own_field' => ['label' => 'Own', 'type' => 'text'],
+            ],
+        ]);
+
+        // Both ends of the cycle contribute their fields; no infinite recursion.
+        $this->assertArrayHasKey('field_a', $result['fields']);
+        $this->assertArrayHasKey('field_b', $result['fields']);
+        $this->assertArrayHasKey('own_field', $result['fields']);
+    }
+
+    /**
+     * @testdox skips a missing include file without error
+     */
+    public function testMissingIncludeIsSkipped()
+    {
+        $result = $this->resolveIncludes([
+            'include' => $this->includePath('_does_not_exist.yaml'),
+            'fields' => [
+                'title' => ['label' => 'Title', 'type' => 'text'],
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('include', $result);
+        $this->assertArrayHasKey('title', $result['fields']);
+        $this->assertCount(1, $result['fields']);
+    }
+
+    /**
+     * @testdox accepts a list of includes merged in order
+     */
+    public function testMultipleIncludes()
+    {
+        $result = $this->resolveIncludes([
+            'include' => [
+                $this->includePath('_base.yaml'),
+                $this->includePath('_shared.yaml'),
+            ],
+            'fields' => [
+                'title' => ['label' => 'Title', 'type' => 'text'],
+            ],
+        ]);
+
+        $this->assertArrayHasKey('base_field', $result['fields']);
+        $this->assertArrayHasKey('shared_field', $result['fields']);
+        $this->assertArrayHasKey('title', $result['fields']);
+    }
+
+    /**
+     * @testdox leaves a block without an include untouched
+     */
+    public function testNoIncludeIsNoop()
+    {
+        $config = [
+            'fields' => [
+                'title' => ['label' => 'Title', 'type' => 'text'],
+            ],
+        ];
+
+        $this->assertEquals($config, $this->resolveIncludes($config));
+    }
+
     public function testCanRegisterBlocksDirectly()
     {
         $this->manager->registerBlock('container', $this->fixturePath . 'container.block');

--- a/tests/classes/BlockManagerTest.php
+++ b/tests/classes/BlockManagerTest.php
@@ -167,6 +167,21 @@ class BlockManagerTest extends PluginTestCase
     }
 
     /**
+     * @testdox on key collision between two includes, the later include wins
+     */
+    public function testLaterIncludeOverridesEarlierInclude()
+    {
+        $result = $this->resolveIncludes([
+            'include' => [
+                $this->includePath('_order_a.yaml'),
+                $this->includePath('_order_b.yaml'),
+            ],
+        ]);
+
+        $this->assertSame('From B', $result['fields']['ordered_field']['label']);
+    }
+
+    /**
      * @testdox leaves a block without an include untouched
      */
     public function testNoIncludeIsNoop()

--- a/tests/fixtures/blocks/includes/_base.yaml
+++ b/tests/fixtures/blocks/includes/_base.yaml
@@ -1,0 +1,4 @@
+fields:
+    base_field:
+        label: Base
+        type: textarea

--- a/tests/fixtures/blocks/includes/_cycle_a.yaml
+++ b/tests/fixtures/blocks/includes/_cycle_a.yaml
@@ -1,0 +1,5 @@
+include: $/winter/blocks/tests/fixtures/blocks/includes/_cycle_b.yaml
+fields:
+    field_a:
+        label: A
+        type: text

--- a/tests/fixtures/blocks/includes/_cycle_b.yaml
+++ b/tests/fixtures/blocks/includes/_cycle_b.yaml
@@ -1,0 +1,5 @@
+include: $/winter/blocks/tests/fixtures/blocks/includes/_cycle_a.yaml
+fields:
+    field_b:
+        label: B
+        type: text

--- a/tests/fixtures/blocks/includes/_order_a.yaml
+++ b/tests/fixtures/blocks/includes/_order_a.yaml
@@ -1,0 +1,4 @@
+fields:
+    ordered_field:
+        label: From A
+        type: text

--- a/tests/fixtures/blocks/includes/_order_b.yaml
+++ b/tests/fixtures/blocks/includes/_order_b.yaml
@@ -1,0 +1,4 @@
+fields:
+    ordered_field:
+        label: From B
+        type: text

--- a/tests/fixtures/blocks/includes/_shared.yaml
+++ b/tests/fixtures/blocks/includes/_shared.yaml
@@ -1,0 +1,11 @@
+fields:
+    shared_field:
+        label: Shared
+        type: text
+    overridden:
+        label: From include
+        type: text
+config:
+    shared_config:
+        label: Shared config
+        type: checkbox

--- a/tests/fixtures/blocks/includes/_with_nested.yaml
+++ b/tests/fixtures/blocks/includes/_with_nested.yaml
@@ -1,0 +1,5 @@
+include: $/winter/blocks/tests/fixtures/blocks/includes/_base.yaml
+fields:
+    mid_field:
+        label: Mid
+        type: text

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,2 +1,5 @@
 '1.0.0':
     - 'First version of Winter.Blocks'
+'1.1.0':
+    - 'Shared field includes with nested include resolution'
+    - 'Recently used blocks pinned to the Add Block palette'


### PR DESCRIPTION
Split out of #68 (closed in favor of smaller, focused PRs).

## Summary
- `.block` definitions may declare a top-level `include:` (string or list) to merge `fields` and `config` from external plain-YAML files, resolved via `File::symbolizePath()` (`$/`, `~/`, `#/`).
- Included definitions form the base; the block's own definitions override on collision. Multiple includes merge in order, with later includes overriding earlier ones.
- Nested includes are supported, with a circular-reference guard.
- Recently-used blocks are pinned to the top of the "Add Block" palette (tracked per-browser in `localStorage`).

See the README sections "Including shared field definitions" and "Recently used blocks" for usage.

## Test plan
- [x] New tests in `tests/classes/BlockManagerTest.php` covering merge precedence (including multi-include override order), nested includes, circular-include guarding, and missing-file handling
- [x] Full plugin test suite passes (`php artisan winter:test -p Winter.Blocks`)