### PR TITLE
Add server-side copy/cut/paste/duplicate for blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+## Unreleased
+
+### Editor UX
+- **Copy / Cut / Paste / Duplicate blocks** — each block has one horizontal
+  toolbar (collapse, copy, cut, paste, duplicate, config, delete). Copy/cut/
+  duplicate place the block's full field data on the clipboard (`sessionStorage`);
+  paste inserts after a block, or appends via a "Paste block" entry at the top
+  of the *+ Add New Item* palette (for empty widgets). Duplicate also clones in
+  place. Paste affordances appear only where the copied block type is offered
+  (respects `allow`/`ignore`/`tags`) and survive navigation within the same
+  browser tab. Direct add/paste/duplicate requests run the same empty-add-item
+  cleanup as the core popover flow, so "Add new item" rows no longer pile up.
+- **Server-side copy/paste** — copying a block calls `onCopyItem`, which builds
+  the block's Form widget server-side and calls `getSaveData()`. This correctly
+  captures every field type — switches, mediafinders, and nested repeaters with
+  their own rows — which a client-side DOM scrape cannot. The clipboard payload
+  (`{group, config, data}`) is sent back to `onAddItem` as `_paste_data`, which
+  seeds the new item via `getValueFromIndex()` before rendering, so the pasted
+  block appears fully populated without a round-trip DOM fill step.
+- Richeditor/codeeditor widgets are automatically refreshed after a paste fill,
+  since the server-populated fields bypass their normal client-side init.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,25 @@ config:
 </{{ config.size }}>
 ```
 
+## Cut, paste and duplicate blocks
+
+Every block has a single horizontal toolbar (top-right) with, in order:
+**collapse**, **copy**, **cut**, **paste**, **duplicate**, *(config, if the
+block has an inspector)* and **delete**.
+
+- **Copy** — places the block's field values on the clipboard (non-destructive).
+- **Cut** — places the block's field values on the clipboard, then removes it (with the usual confirmation prompt).
+- **Paste after** — once the clipboard holds a block, a per-block paste icon inserts the copied block immediately **after** that block. A **Paste block** entry also appears at the top of the "Add Block" palette (the popover opened by *+ Add New Item*), which is handy for inserting into an empty widget or at the end of a list.
+- **Duplicate** — one-step clone: serialises the current block, saves it to the clipboard, and immediately inserts a filled copy right after it.
+
+Use **Duplicate** for a quick in-place clone. Use **Paste after** (or **Paste block** in the palette) when you want to insert a previously copied block at a specific position or into a different widget.
+
+Paste/duplicate respect the widget's `allow` / `ignore` / `tags` constraints: the paste affordances only appear where the copied block type is actually offered. The clipboard persists for the duration of the browser session (`sessionStorage`), so you can paste across different pages in the same tab.
+
+> **How copy/paste works:** Copying a block calls a server-side handler (`onCopyItem`) that builds the block's form widget and calls `getSaveData()`. This correctly captures every field type — including switches, mediafinders, and nested repeaters with their own rows — which a client-side DOM scrape cannot. The payload is stored in `sessionStorage` and sent back on paste, where the new item is rendered server-side pre-populated. Rich-text and code editor widgets are refreshed via their own APIs after the item is inserted into the DOM.
+
+---
+
 ## Using the `blocks` FormWidget
 
 In order to provide an interface for managing block-based content, this plugin provides the `blocks` FormWidget. This widget can be used in the backend as a form field to manage blocks.

--- a/formwidgets/Blocks.php
+++ b/formwidgets/Blocks.php
@@ -33,6 +33,14 @@ class Blocks extends Repeater
     public array $indexConfigMeta = [];
 
     /**
+     * Block data to seed into a freshly added item, keyed by index. Used by the
+     * server-side paste flow so a pasted block renders fully populated (switches,
+     * mediafinders, nested repeaters) instead of relying on lossy client-side
+     * field scraping.
+     */
+    protected array $pasteData = [];
+
+    /**
      * {@inheritDoc}
      */
     public function init()
@@ -168,6 +176,51 @@ class Blocks extends Repeater
 
     /**
      * {@inheritDoc}
+     *
+     * Returns the data at a given index, preferring data seeded for the
+     * server-side paste flow (see onAddItem).
+     */
+    protected function getValueFromIndex($index)
+    {
+        if (array_key_exists($index, $this->pasteData)) {
+            return $this->pasteData[$index];
+        }
+
+        return parent::getValueFromIndex($index);
+    }
+
+    /**
+     * Returns the full saved data for a single block item, for the copy/cut/
+     * duplicate clipboard. Building the item's Form widget and calling
+     * getSaveData() captures every field type correctly — including switches,
+     * mediafinders and nested repeaters — which a client-side DOM scrape cannot.
+     */
+    public function onCopyItem()
+    {
+        $index = post('_repeater_index');
+        $groupCode = post('_repeater_group');
+
+        $this->prepareVars();
+        $widget = $this->makeItemFormWidget($index, $groupCode);
+
+        // The Inspector config is repeater meta, not a form field, so read it
+        // straight from the posted item value rather than getSaveData().
+        $config = array_get(parent::getValueFromIndex($index), '_config') ?: null;
+
+        return [
+            'result' => json_encode([
+                'group'  => $groupCode,
+                'config' => $config,
+                'data'   => $widget->getSaveData(),
+            ]),
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Accepts optional `_paste_data` (a JSON-encoded block data array from
+     * onCopyItem) and `_paste_config` to render the new item pre-populated.
      */
     public function onAddItem()
     {
@@ -175,16 +228,50 @@ class Blocks extends Repeater
 
         $index = $this->getNextIndex();
 
+        $pasteConfig = null;
+        $isPaste = false;
+        if ($pasteRaw = post('_paste_data')) {
+            $decoded = json_decode($pasteRaw, true);
+            if (is_array($decoded)) {
+                $this->pasteData[$index] = $decoded;
+                $pasteConfig = post('_paste_config') ?: null;
+                $isPaste = true;
+            }
+        }
+
+        // Keep the static $onAddItemCalled flag set during prepareVars() so the
+        // OUTER repeater skips re-processing every existing item (Repeater.php:179)
+        // — we only render the new item here, so rebuilding the rest is wasted work.
         $this->prepareVars();
-        $this->vars['widget'] = $this->makeItemFormWidget($index, $groupCode);
-        $this->vars['indexValue'] = $index;
+
+        // Repeater::$onAddItemCalled is a *static* flag set during init() of the
+        // repeater handling this AJAX request. While set, every repeater —
+        // including any nested repeater inside the new item — skips processItems()
+        // (Repeater.php:158,179), which normally stops a new empty item pulling a
+        // sibling's data. But when pasting we *want* the new item's nested
+        // repeaters to build their rows from the seeded data, so clear the flag
+        // only while building and rendering the new item, then restore it.
+        $restoreAddItemFlag = self::$onAddItemCalled;
+        if ($isPaste) {
+            self::$onAddItemCalled = false;
+        }
+
+        try {
+            $this->vars['widget'] = $this->makeItemFormWidget($index, $groupCode);
+            $this->vars['indexValue'] = $index;
+            $this->indexConfigMeta[$index] = $pasteConfig;
+
+            $html = $this->makePartial('block_item') . $this->makePartial('block_add_item');
+        } finally {
+            self::$onAddItemCalled = $restoreAddItemFlag;
+        }
 
         $itemContainer = '@#' . $this->getId('items');
         $addItemContainer = '#' . $this->getId('add-item');
 
         return [
             $addItemContainer => '',
-            $itemContainer => $this->makePartial('block_item') . $this->makePartial('block_add_item')
+            $itemContainer => $html
         ];
     }
 

--- a/formwidgets/blocks/assets/less/blocks.less
+++ b/formwidgets/blocks/assets/less/blocks.less
@@ -5,6 +5,68 @@
 .field-blocks {
     padding-top: 5px;
 
+    // Per-block toolbar holding every item control in one horizontal row:
+    // collapse, cut, paste, duplicate, config, delete. Overrides the core
+    // fixed 20px width on .repeater-item-remove so the icons never overflow.
+    // Mirrored as an inline-injected <style> in the block widget partial so the
+    // toolbar still renders correctly when the compiled CSS is stale.
+    .field-block-item > .repeater-item-remove.block-item-toolbar {
+        width: auto !important;
+        height: auto !important;
+        display: inline-flex !important;
+        align-items: center;
+        gap: 1px;
+        top: 4px;
+        right: 5px;
+        white-space: nowrap;
+    }
+
+    .block-item-action {
+        float: none;
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        padding: 0;
+        margin: 0;
+        border: 0;
+        background: none;
+        cursor: pointer;
+        color: @text-color;
+        opacity: .6;
+        font-size: 13px;
+        line-height: 1;
+        border-radius: 3px;
+        transition: background .15s, color .15s, opacity .15s;
+
+        > i { line-height: 1; }
+
+        &:hover,
+        &:focus {
+            opacity: 1;
+            background: rgba(0, 0, 0, .06);
+            color: @text-color;
+            text-decoration: none;
+        }
+
+        &.block-item-action-remove:hover {
+            color: #cc3300;
+        }
+
+        // Keep the collapse chevron's rotate-when-collapsed behaviour.
+        &.repeater-item-collapse-one {
+            transition: transform .3s, background .15s, opacity .15s;
+        }
+    }
+
+    // Rotate the collapse chevron when the item is collapsed (it now lives in
+    // the toolbar rather than the original .repeater-item-collapse wrapper).
+    .field-block-item.collapsed > .repeater-item-remove .repeater-item-collapse-one {
+        transform: rotate(180deg);
+    }
+
     .field-block-items {
         counter-reset: repeater-index-counter;
     }

--- a/formwidgets/blocks/partials/_block.php
+++ b/formwidgets/blocks/partials/_block.php
@@ -5,6 +5,9 @@
     <?= $maxItems ? 'data-max-items="'.$maxItems.'"' : '' ?>
     <?= $style ? 'data-style="'.$style.'"' : '' ?>
     data-mode="<?= $mode ?>"
+    data-add-handler="<?= $this->getEventHandler('onAddItem') ?>"
+    data-copy-handler="<?= $this->getEventHandler('onCopyItem') ?>"
+    data-block-codes="<?= e(implode(',', array_keys($groupDefinitions))) ?>"
     <?php if ($mode === 'grid'): ?> data-columns="<?= $columns ?>" <?php endif ?>
     <?php if ($sortable) : ?>
     data-sortable="true"
@@ -84,5 +87,355 @@
                 </div>
             </div>
         </div>
+    </script>
+
+    <?php
+    /*
+     * Inline bootstrap for copy/cut/paste/duplicate of blocks. Loaded inline
+     * (rather than only via addJs) so it is guaranteed to reach the page
+     * regardless of widget asset-path resolution or the asset combiner. A
+     * global guard ensures the handlers are registered only once even when
+     * several block widgets render on the same page.
+     *
+     * Copying/duplicating a block round-trips to the server (onCopyItem),
+     * which builds the item's Form widget and calls getSaveData() — this
+     * correctly captures every field type (switches, mediafinders, nested
+     * repeaters) which a client-side DOM scrape cannot. Pasting posts the
+     * clipboard payload back to onAddItem as `_paste_data`, and the server
+     * renders the new item fully populated.
+     */
+    ?>
+    <script>
+    (function () {
+        if (window.__blockCopyPasteInit) { return; }
+        window.__blockCopyPasteInit = true;
+
+        var CLIPBOARD_KEY = 'wnBlocksClipboard';
+
+        // --- inject toolbar styles once ------------------------------------
+        // Kept here (rather than only in blocks.less) so the per-block toolbar
+        // (collapse / copy / cut / paste / duplicate / config / delete) renders
+        // correctly even if the compiled CSS is stale.
+        (function injectToolbarCss() {
+            if (document.getElementById('wn-blocks-toolbar-css')) { return; }
+            var css =
+                '.field-block-item>.repeater-item-remove.block-item-toolbar{width:auto!important;' +
+                'height:auto!important;display:inline-flex!important;align-items:center;' +
+                'gap:1px;top:4px;right:5px;white-space:nowrap}' +
+                '.block-item-action{float:none;flex:0 0 auto;display:inline-flex;' +
+                'align-items:center;justify-content:center;width:22px;height:22px;padding:0;' +
+                'margin:0;border:0;background:none;cursor:pointer;color:#333;opacity:.6;' +
+                'font-size:13px;line-height:1;border-radius:3px;' +
+                'transition:background .15s,color .15s,opacity .15s}' +
+                '.block-item-action>i{line-height:1}' +
+                '.block-item-action:hover,.block-item-action:focus{opacity:1;' +
+                'background:rgba(0,0,0,.06);color:#333;text-decoration:none}' +
+                '.block-item-action-remove:hover{color:#cc3300}' +
+                '.field-block-item.collapsed>.repeater-item-remove .repeater-item-collapse-one' +
+                '{transform:rotate(180deg)}' +
+                // Dim-show the toolbar on blocks where clipboard paste is available so the
+                // user sees the paste icon without having to hover. Full opacity on hover.
+                '.field-block-item.has-paste>.repeater-item-remove.block-item-toolbar{opacity:.45!important}' +
+                '.field-block-item.has-paste.hover>.repeater-item-remove.block-item-toolbar,' +
+                '.field-block-item.has-paste.focus>.repeater-item-remove.block-item-toolbar{opacity:1!important}';
+            var style = document.createElement('style');
+            style.id = 'wn-blocks-toolbar-css';
+            style.textContent = css;
+            (document.head || document.documentElement).appendChild(style);
+        })();
+
+        // --- safe sessionStorage helpers -----------------------------------
+        function ssGet(key) {
+            try { return window.sessionStorage.getItem(key); } catch (e) { return null; }
+        }
+        function ssSet(key, val) {
+            try { window.sessionStorage.setItem(key, val); } catch (e) {}
+        }
+
+        // --- block clipboard (copy / cut / paste) -------------------------
+        function getClipboard() {
+            try {
+                var raw = ssGet(CLIPBOARD_KEY);
+                return raw ? JSON.parse(raw) : null;
+            } catch (e) { return null; }
+        }
+
+        // Copy a block item's full saved data to the clipboard via the server.
+        // A server round-trip (onCopyItem -> Form::getSaveData) captures every
+        // field type correctly — switches, mediafinders, nested repeaters — which
+        // a client-side DOM scrape cannot. Stored payload: { group, config, data }.
+        // `done(payload)` runs once the clipboard has been set.
+        function copyItemToClipboard(li, done) {
+            if (typeof $ === 'undefined' || !li) { return; }
+            var fieldBlocks = li.closest('.field-blocks');
+            var handler = fieldBlocks && fieldBlocks.getAttribute('data-copy-handler');
+            var index = li.getAttribute('data-block-index');
+            var group = li.getAttribute('data-block-group');
+            if (!handler || index === null) { return; }
+            $(fieldBlocks).request(handler, {
+                data: { _repeater_index: index, _repeater_group: group },
+                success: function (response) {
+                    var payload;
+                    try { payload = JSON.parse(response.result); } catch (e) { return; }
+                    if (!payload || !payload.group) { return; }
+                    ssSet(CLIPBOARD_KEY, JSON.stringify(payload));
+                    updatePasteButtons();
+                    if (typeof done === 'function') { done(payload); }
+                }
+            });
+        }
+
+        // Is the given block code offered by this widget? Reads the explicit
+        // data-block-codes list rendered server-side on the .field-blocks element.
+        function blockTypeAvailable(fieldBlocks, group) {
+            if (!fieldBlocks) { return false; }
+            var list = fieldBlocks.getAttribute('data-block-codes') || '';
+            return list.split(',').indexOf(group) !== -1;
+        }
+
+        // Show/hide paste affordances based on clipboard state and widget availability.
+        // Per-item paste buttons show only when the clipboard holds a block this
+        // widget accepts. (The append case is handled in the Add-Item palette.)
+        function updatePasteButtons() {
+            var cb = getClipboard();
+            var ok = cb && cb.group;
+            document.querySelectorAll('[data-block-paste]').forEach(function (btn) {
+                var fieldBlocks = btn.closest('.field-blocks');
+                var show = ok && blockTypeAvailable(fieldBlocks, cb.group);
+                btn.style.display = show ? '' : 'none';
+                // Add/remove has-paste on the parent li so the CSS can dim-show the toolbar.
+                var li = btn.closest('.field-block-item');
+                if (li) { li.classList.toggle('has-paste', !!show); }
+            });
+        }
+
+        // The onAddItem AJAX handler name, rendered server-side on .field-blocks.
+        function findAddHandler(fieldBlocks) {
+            return fieldBlocks ? fieldBlocks.getAttribute('data-add-handler') : null;
+        }
+
+        // onAddItem returns an empty add-item plus a fresh one; the core popover
+        // flow removes the empty leftovers afterwards, but our direct requests
+        // bypass that — so replicate the cleanup ourselves to avoid stray
+        // "Add new item" buttons piling up.
+        function cleanupAddItems(fieldBlocks) {
+            if (typeof $ === 'undefined' || !fieldBlocks) { return; }
+            $(fieldBlocks).find('.field-repeater-items > .field-repeater-add-item')
+                .each(function () {
+                    if (this.children.length === 0) { $(this).remove(); }
+                });
+        }
+
+        // Fire onAddItem with the copied block's data so the server renders the
+        // new item fully populated. We only remember where to move the new <li>
+        // once it arrives; the server handles all field population.
+        function requestPaste(fieldBlocks, payload, afterLi) {
+            var handler = findAddHandler(fieldBlocks);
+            if (!handler || typeof $ === 'undefined' || !payload || !payload.group) { return; }
+            window.__pendingPasteMove = { afterLi: afterLi || null };
+            $(window).one('ajaxUpdateComplete', function () {
+                cleanupAddItems(fieldBlocks);
+            });
+            $(fieldBlocks).request(handler, {
+                data: {
+                    _repeater_group: payload.group,
+                    _paste_data: JSON.stringify(payload.data || {}),
+                    _paste_config: payload.config || ''
+                }
+            });
+        }
+
+        // Collapse chevron (moved into the toolbar, so the core delegated handler
+        // — bound to .repeater-item-collapse .repeater-item-collapse-one — no longer
+        // fires on it). Toggle the item's collapsed state ourselves; the CSS handles
+        // the rest. Document-level delegation also covers dynamically added blocks.
+        document.addEventListener('click', function (e) {
+            var btn = e.target.closest('.block-item-toolbar .repeater-item-collapse-one');
+            if (!btn) { return; }
+            e.preventDefault();
+            e.stopPropagation();
+            var item = btn.closest('.field-repeater-item');
+            if (item) { item.classList.toggle('collapsed'); }
+        });
+
+        // Copy button: place the block's field values on the clipboard (non-destructive).
+        document.addEventListener('click', function (e) {
+            var btn = e.target.closest('[data-block-copy]');
+            if (!btn) { return; }
+            e.preventDefault();
+            e.stopPropagation();
+            var li = btn.closest('.field-block-item');
+            copyItemToClipboard(li);
+        });
+
+        // Duplicate button: clone this block in place (insert a copy right after it)
+        // and also place it on the clipboard so it can be pasted into other widgets.
+        document.addEventListener('click', function (e) {
+            var btn = e.target.closest('[data-block-duplicate]');
+            if (!btn) { return; }
+            e.preventDefault();
+            e.stopPropagation();
+            var li = btn.closest('.field-block-item');
+            if (!li) { return; }
+            copyItemToClipboard(li, function (payload) {
+                requestPaste(li.closest('.field-blocks'), payload, li);
+            });
+        });
+
+        // Cut button: copy then trigger the existing remove button (with confirm).
+        document.addEventListener('click', function (e) {
+            var btn = e.target.closest('[data-block-cut]');
+            if (!btn) { return; }
+            e.stopPropagation();
+            var li = btn.closest('.field-block-item');
+            if (!li) { return; }
+            copyItemToClipboard(li, function () {
+                var removeBtn = li.querySelector('[data-repeater-remove]');
+                if (removeBtn) { removeBtn.click(); }
+            });
+        });
+
+        // Remember which widget's Add-Item palette is open, so a paste entry
+        // injected into the (body-level) popover knows where to insert.
+        document.addEventListener('click', function (e) {
+            var add = e.target.closest('[data-repeater-add-group]');
+            if (add) { window.__activeBlocksWidget = add.closest('.field-blocks'); }
+        });
+
+        // Inject a "Paste block" entry at the top of the Add-Item palette grid.
+        // Looks identical to real block items. Injected once per palette open;
+        // subsequent MutationObserver calls hit the early-exit guard (matching
+        // data-paste-group) and make no DOM changes, so the observer loop stops.
+        function injectPalettePaste(grid) {
+            var cb = getClipboard();
+            var fieldBlocks = window.__activeBlocksWidget;
+            var show = !!(cb && cb.group && blockTypeAvailable(fieldBlocks, cb.group));
+
+            var existing = grid.querySelector('.blocks-paste-item');
+            if (existing) {
+                // Already injected with the right group — nothing to do.
+                if (show && existing.dataset.pasteGroup === cb.group) { return; }
+                existing.remove();
+            }
+            if (!show) { return; }
+
+            var capturedFieldBlocks = fieldBlocks;
+            var capturedGroup = cb.group;
+            var capturedPayload = cb;
+
+            var a = document.createElement('a');
+            a.href = 'javascript:;';
+            a.innerHTML =
+                '<i class="icon-paste"></i>' +
+                '<div><span class="title">Paste block</span>' +
+                '<span class="description">Insert copied block</span></div>';
+            a.addEventListener('click', function () {
+                requestPaste(capturedFieldBlocks, capturedPayload, null);
+            });
+
+            var item = document.createElement('div');
+            item.className = 'blocks-group-item blocks-paste-item';
+            item.dataset.pasteGroup = capturedGroup;
+            item.appendChild(a);
+            grid.insertBefore(item, grid.firstChild);
+        }
+
+        // Paste button on each block item — inserts the copied block immediately
+        // after it. Fires onAddItem; the MutationObserver moves the new <li> into place.
+        document.addEventListener('click', function (e) {
+            var btn = e.target.closest('[data-block-paste]');
+            if (!btn || !btn.closest('.field-block-item')) { return; }
+            e.preventDefault();
+            e.stopPropagation();
+            var cb = getClipboard();
+            if (!cb || !cb.group) { return; }
+            var li = btn.closest('.field-block-item');
+            requestPaste(li.closest('.field-blocks'), cb, li);
+        });
+
+        // --- refresh rich text / code editors after a paste fill ----------
+        // The server fills the new item's fields directly into the DOM, which
+        // bypasses the richeditor/codeeditor widgets' own init — so their visual
+        // editor still shows empty. Re-sync them from the underlying textarea
+        // once the item is in place.
+        function refreshRichWidgets(li) {
+            if (typeof $ === 'undefined' || !li) { return; }
+            $(li).find('[data-control="richeditor"]').each(function () {
+                var $el = $(this);
+                if ($el.data('oc.richeditor') && typeof $el.richEditor === 'function') {
+                    $el.richEditor('setContent', $el.val());
+                }
+            });
+            $(li).find('[data-control="codeeditor"]').each(function () {
+                var $el = $(this);
+                if ($el.data('oc.codeeditor') && typeof $el.codeEditor === 'function') {
+                    $el.codeEditor('refresh');
+                }
+            });
+        }
+
+        // --- shared init + observer ----------------------------------------
+        function runAll() {
+            document.querySelectorAll('.blocks-group-grid').forEach(injectPalettePaste);
+        }
+
+        runAll();
+        updatePasteButtons();
+        document.querySelectorAll('.field-blocks').forEach(cleanupAddItems);
+
+        var scheduled = false;
+        var pendingNewNodes = false;
+        var observer = new MutationObserver(function (mutations) {
+            // When a paste is pending, find the newly added block <li>, move it after
+            // the source block, and fill its fields — all before the debounced runAll fires.
+            if (window.__pendingPasteMove) {
+                var pending = window.__pendingPasteMove;
+                for (var i = 0; i < mutations.length; i++) {
+                    mutations[i].addedNodes.forEach(function (node) {
+                        if (node.nodeType === 1 && node.classList &&
+                                node.classList.contains('field-block-item')) {
+                            window.__pendingPasteMove = null;
+                            // The server already populated the fields; we only
+                            // move the new item to sit after the source block,
+                            // then refresh any rich text / code editor widgets.
+                            if (pending.afterLi && pending.afterLi.parentNode) {
+                                pending.afterLi.parentNode.insertBefore(
+                                    node, pending.afterLi.nextSibling
+                                );
+                            }
+                            refreshRichWidgets(node);
+                        }
+                    });
+                }
+            }
+            // Track whether any element nodes were added in this batch.
+            // updatePasteButtons and cleanupAddItems are called explicitly by
+            // copy/cut/duplicate handlers; the observer only needs to run them
+            // when the DOM gains new elements (e.g. a block was added).
+            if (!pendingNewNodes) {
+                pendingNewNodes = mutations.some(function (m) { return m.addedNodes.length > 0; });
+            }
+            if (scheduled) { return; }
+            scheduled = true;
+            setTimeout(function () {
+                scheduled = false;
+                var hadNewNodes = pendingNewNodes;
+                pendingNewNodes = false;
+                runAll();
+                if (hadNewNodes) {
+                    updatePasteButtons();
+                    document.querySelectorAll('.field-blocks').forEach(cleanupAddItems);
+                }
+            }, 0);
+        });
+        function startObserving() {
+            if (document.body) {
+                observer.observe(document.body, { childList: true, subtree: true });
+            } else {
+                document.addEventListener('DOMContentLoaded', startObserving);
+            }
+        }
+        startObserving();
+    })();
     </script>
 </div>

--- a/formwidgets/blocks/partials/_block_item.php
+++ b/formwidgets/blocks/partials/_block_item.php
@@ -7,31 +7,68 @@ $itemIcon = $this->getGroupIcon($groupCode);
 ?>
 <li
     class="field-repeater-item field-block-item<?php if (!count($widget->getFields())): ?> empty<?php endif ?>"
+    data-block-index="<?= $indexValue ?>"
+    data-block-group="<?= $groupCode ?>"
     <?php if ($mode === 'grid'): ?>style="min-height: <?= $rowHeight ?>px"<?php endif ?>
 >
 
-    <?php if (!$this->previewMode) : ?>
-        <div class="repeater-item-remove">
+    <?php
+    /*
+     * All item controls live in one horizontal toolbar so they never overflow.
+     * Order: collapse, copy, cut, paste, duplicate, [config], delete.
+     */
+    ?>
+    <div class="repeater-item-remove block-item-toolbar">
+        <?php if (count($widget->getFields()) && $mode !== 'grid'): ?>
+            <a href="javascript:;" class="repeater-item-collapse-one block-item-action" aria-label="Collapse" title="Collapse">
+                <i class="icon-chevron-up"></i>
+            </a>
+        <?php endif ?>
+
+        <?php if (!$this->previewMode): ?>
+            <button type="button" class="block-item-action" aria-label="Copy block" title="Copy" data-block-copy>
+                <i class="icon-copy"></i>
+            </button>
+            <button type="button" class="block-item-action" aria-label="Cut block" title="Cut" data-block-cut>
+                <i class="icon-scissors"></i>
+            </button>
+            <button type="button" class="block-item-action" aria-label="Paste after this block" title="Paste after" data-block-paste style="display:none">
+                <i class="icon-paste"></i>
+            </button>
+            <button type="button" class="block-item-action" aria-label="Duplicate block" title="Duplicate" data-block-duplicate>
+                <i class="icon-clone"></i>
+            </button>
+        <?php endif ?>
+
+        <?php if ($this->hasInspectorConfig($groupCode)): ?>
+            <a
+                href="javascript:;"
+                class="block-config block-item-action"
+                data-inspectable
+                data-inspector-title="<?= e(trans($itemTitle)) ?>"
+                data-inspector-description="<?= e(trans($itemDescription)) ?>"
+                data-inspector-config="<?= e($this->getInspectorConfig($groupCode)) ?>"
+                data-inspector-offset-y="-5"
+                data-inspector-offset-x="-15"
+            >
+                <i class="icon-cog"></i>
+                <input type="hidden" data-inspector-values name="<?= $widget->arrayName ?>[_config]" value="<?= e($groupConfig ?: '{}') ?>" />
+            </a>
+        <?php endif ?>
+
+        <?php if (!$this->previewMode): ?>
             <button
                 type="button"
-                class="close"
+                class="block-item-action block-item-action-remove"
                 aria-label="Remove"
                 data-repeater-remove
                 data-request="<?= $this->getEventHandler('onRemoveItem') ?>"
                 data-request-data="'_repeater_index': '<?= $indexValue ?>', '_repeater_group': '<?= $groupCode ?>'"
                 data-request-confirm="<?= e(trans('backend::lang.form.action_confirm')) ?>">
-                <span aria-hidden="true">&times;</span>
+                <i class="icon-times"></i>
             </button>
-        </div>
-    <?php endif ?>
-
-    <?php if (count($widget->getFields()) && $mode !== 'grid'): ?>
-        <div class="repeater-item-collapse">
-            <a href="javascript:;" class="repeater-item-collapse-one">
-                <i class="icon-chevron-up"></i>
-            </a>
-        </div>
-    <?php endif ?>
+        <?php endif ?>
+    </div>
 
     <div class="repeater-item-collapsed-handle">&nbsp;</div>
 
@@ -43,22 +80,6 @@ $itemIcon = $this->getGroupIcon($groupCode);
 
         <input type="hidden" name="<?= $widget->arrayName ?>[_group]" value="<?= $groupCode ?>" />
     </div>
-
-    <?php if ($this->hasInspectorConfig($groupCode)): ?>
-        <a
-            href="javascript:;"
-            class="block-config"
-            data-inspectable
-            data-inspector-title="<?= e(trans($itemTitle)) ?>"
-            data-inspector-description="<?= e(trans($itemDescription)) ?>"
-            data-inspector-config="<?= e($this->getInspectorConfig($groupCode)) ?>"
-            data-inspector-offset-y="-5"
-            data-inspector-offset-x="-15"
-        >
-            <i class="icon-cog"></i>
-            <input type="hidden" data-inspector-values name="<?= $widget->arrayName ?>[_config]" value="<?= e($groupConfig ?: '{}') ?>" />
-        </a>
-    <?php endif ?>
 
     <div class="field-repeater-form"
          data-control="formwidget"

--- a/tests/fixtures/blocks/complex.block
+++ b/tests/fixtures/blocks/complex.block
@@ -1,0 +1,19 @@
+name: Complex
+description: Block with a switch and a nested repeater of blocks, used for copy/paste tests
+icon: icon-square
+tags: ["content"]
+fields:
+    title:
+        label: Title
+        type: text
+    enabled:
+        label: Enabled
+        type: switch
+        default: true
+    items:
+        label: false
+        type: blocks
+        span: full
+        allow:
+            - title
+==

--- a/tests/formwidgets/BlocksTest.php
+++ b/tests/formwidgets/BlocksTest.php
@@ -6,6 +6,7 @@ use Backend\Classes\Controller;
 use Backend\Classes\FormField;
 use Backend\Widgets\Form;
 use Cms\Classes\Theme;
+use Illuminate\Support\Facades\Request;
 use System\Tests\Bootstrap\PluginTestCase;
 use Winter\Blocks\Classes\BlockManager;
 use Winter\Blocks\FormWidgets\Blocks;
@@ -34,11 +35,14 @@ class BlocksTest extends PluginTestCase
         Theme::resetCache();
     }
 
-    protected function createTestFormWidget(array $config = []): Blocks
+    protected function createTestFormWidget(array $config = [], ?array $content = null): Blocks
     {
         Theme::load('blocktest');
         $controller = new Controller();
         $model = new Page();
+        if ($content !== null) {
+            $model->content = $content;
+        }
         $form = new Form($controller, [
             'model' => $model,
             'fields' => [],
@@ -56,6 +60,16 @@ class BlocksTest extends PluginTestCase
 
         $widget->init();
         return $widget;
+    }
+
+    /**
+     * Swaps in a fake POST request so the post() helper (used throughout
+     * Repeater/Blocks AJAX handlers) returns the given values for the
+     * duration of the test.
+     */
+    protected function fakePostRequest(array $data): void
+    {
+        Request::swap(\Illuminate\Http\Request::create('/', 'POST', $data));
     }
 
     public function testCanCreateFormWidget()
@@ -78,5 +92,123 @@ class BlocksTest extends PluginTestCase
         $this->assertEquals('Rich text', $widget->getGroupTitle('richtext'));
         $this->assertEquals('Title', $widget->getGroupTitle('title'));
         $this->assertNull($widget->getGroupTitle('container'));
+    }
+
+    /**
+     * @testdox onCopyItem() returns the full saved data for a block, including a switch and a nested repeater of blocks
+     */
+    public function testOnCopyItemReturnsFullSavedData()
+    {
+        BlockManager::instance()->registerBlock('complex', $this->fixturePath . 'complex.block');
+        BlockManager::instance()->registerBlock('title', $this->fixturePath . 'title.block');
+
+        $widget = $this->createTestFormWidget(['alias' => 'blocks'], [
+            [
+                '_group' => 'complex',
+                'title' => 'Hello',
+                'enabled' => '1',
+                'items' => [
+                    ['_group' => 'title', 'content' => 'Nested text'],
+                ],
+            ],
+        ]);
+
+        // onCopyItem() builds its Form widget and reads its value via
+        // getSaveData(), which (like a real save) reads straight from the
+        // posted form data at the item's array-name path -- this is exactly
+        // what a normal AJAX request submits alongside the handler name, so
+        // we replicate the full nested POST structure here rather than only
+        // the two meta fields.
+        $this->fakePostRequest([
+            '_repeater_index' => 0,
+            '_repeater_group' => 'complex',
+            'content' => [
+                0 => [
+                    'title' => 'Hello',
+                    'enabled' => '1',
+                    'items' => [
+                        0 => ['_group' => 'title', 'content' => 'Nested text'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $widget->onCopyItem();
+        $payload = json_decode($result['result'], true);
+
+        $this->assertEquals('complex', $payload['group']);
+        $this->assertEquals('Hello', $payload['data']['title']);
+        $this->assertEquals(1, (int) $payload['data']['enabled']);
+        $this->assertCount(1, $payload['data']['items']);
+        $this->assertEquals('Nested text', $payload['data']['items'][0]['content']);
+    }
+
+    /**
+     * @testdox onAddItem() with _paste_data seeds the new item (including its nested repeater of blocks) without touching existing items
+     */
+    public function testOnAddItemWithPasteDataSeedsNewItemWithoutClobberingExistingItems()
+    {
+        BlockManager::instance()->registerBlock('complex', $this->fixturePath . 'complex.block');
+        BlockManager::instance()->registerBlock('title', $this->fixturePath . 'title.block');
+
+        $existingItem = [
+            '_group' => 'complex',
+            'title' => 'Existing item',
+            'enabled' => '0',
+            'items' => [],
+        ];
+
+        $widget = $this->createTestFormWidget(['alias' => 'blocks'], [$existingItem]);
+
+        $pasteData = [
+            'title' => 'Pasted item',
+            'enabled' => '1',
+            'items' => [
+                ['_group' => 'title', 'content' => 'Pasted nested text'],
+            ],
+        ];
+
+        // Unlike onCopyItem(), a pasted item hasn't been submitted via a real
+        // form post yet -- onAddItem() seeds it purely from _paste_data, so
+        // no matching "content" POST array is needed here.
+        $this->fakePostRequest([
+            '_repeater_group' => 'complex',
+            '_paste_data' => json_encode($pasteData),
+            '_paste_config' => json_encode(['some' => 'config']),
+        ]);
+
+        $widget->onAddItem();
+
+        // The new item (index 1, since index 0 already existed) is built
+        // from the pasted data -- including its nested repeater of blocks,
+        // not just the top-level fields a client-side DOM scrape could see.
+        /** @var \Backend\Widgets\Form $newItemWidget */
+        $newItemWidget = $widget->vars['widget'];
+
+        $this->assertEquals($pasteData, (array) $newItemWidget->config->data);
+
+        $reflectionFormWidgets = new \ReflectionProperty(\Backend\FormWidgets\Repeater::class, 'formWidgets');
+        $reflectionFormWidgets->setAccessible(true);
+        $formWidgets = $reflectionFormWidgets->getValue($widget);
+
+        $this->assertArrayHasKey(1, $formWidgets, 'Expected a new item to have been added at index 1.');
+
+        /** @var \Backend\FormWidgets\Repeater $nestedItems */
+        $nestedItems = $formWidgets[1]->getFormWidget('items');
+        $reflectionNestedWidgets = new \ReflectionProperty(\Backend\FormWidgets\Repeater::class, 'formWidgets');
+        $reflectionNestedWidgets->setAccessible(true);
+        $nestedFormWidgets = $reflectionNestedWidgets->getValue($nestedItems);
+
+        $this->assertCount(1, $nestedFormWidgets, 'Expected the pasted nested repeater item to have been built.');
+        $this->assertEquals('Pasted nested text', ((array) $nestedFormWidgets[0]->config->data)['content']);
+
+        // The pasted config is tracked against the new item's index.
+        $reflection = new \ReflectionProperty(Blocks::class, 'indexConfigMeta');
+        $reflection->setAccessible(true);
+        $this->assertEquals(['some' => 'config'], json_decode($reflection->getValue($widget)[1], true));
+
+        // The pre-existing item at index 0 was not rebuilt/clobbered by the paste:
+        // its Form widget still carries the data it was originally built with.
+        $this->assertEquals($existingItem, (array) $formWidgets[0]->config->data);
     }
 }

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,2 +1,4 @@
 '1.0.0':
     - 'First version of Winter.Blocks'
+'1.1.0':
+    - 'Server-side copy/cut/paste/duplicate for blocks'


### PR DESCRIPTION
Split out of #68 (closed in favor of smaller, focused PRs).

## Summary
- Copy/Cut/Paste/Duplicate is fully server-side and captures all field types (switches, mediafinders, nested repeaters), which a client-side DOM scrape cannot do reliably.
- Copying calls a server-side handler (`onCopyItem`) that builds the block's form widget and calls `getSaveData()`; pasting renders the new item server-side, pre-populated from the captured payload (stored client-side in `sessionStorage` for the duration of the browser session).
- Toolbar: collapse, copy, cut, paste, duplicate, config (if applicable), delete — plus a "Paste block" entry in the "Add Block" palette for pasting into an empty widget or at the end of a list.
- Paste/duplicate respect the widget's `allow`/`ignore`/`tags` constraints.
- Rich-text and code editor widgets are refreshed via their own APIs after a pasted item is inserted into the DOM.

See the README section "Cut, paste and duplicate blocks" for usage.

## Test plan
- [x] New tests in `tests/formwidgets/BlocksTest.php` verifying copy preserves nested/switch/text field values, and that pasting seeds a new item without clobbering existing ones
- [x] Full plugin test suite passes (`php artisan winter:test -p Winter.Blocks`)