### PR TITLE
Add component: key support to block config resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+### Component-backed block fields
+- `.block` definitions may declare a top-level `component: <componentKey>` to
+  derive default `fields:` from a CMS component's `defineProperties()`.
+  Property types are mapped to block/form field types (string/text → text,
+  integer/float → number, checkbox → checkbox, dropdown → dropdown, set →
+  checkboxlist). The block's own `fields:` always take precedence over the
+  ones derived from the component on key collision.
+- Unknown or unresolvable components are logged as a warning and otherwise
+  ignored, leaving the block's own fields untouched.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ precedence over fields derived from the component on key collision. If the
 component can't be resolved, a warning is logged and the block's own fields
 are used as-is.
 
+---
+
 ## Using the `blocks` FormWidget
 
 In order to provide an interface for managing block-based content, this plugin provides the `blocks` FormWidget. This widget can be used in the backend as a form field to manage blocks.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,36 @@ config:
 </{{ config.size }}>
 ```
 
+## Deriving fields from a component
+
+A block can declare a top-level `component:` key to derive default fields from
+a CMS component's `defineProperties()`, instead of (or alongside) hand-written
+`fields:`.
+
+```yaml
+name: MFA Gateway
+description: Configurable MFA gateway block
+icon: icon-lock
+
+component: mfaGateway
+
+fields:
+    title:
+        label: Title
+        type: text
+==
+{% component 'mfaGateway' %}
+```
+
+The component's properties are converted to block fields (`title` → `label`,
+`description` → `comment`, `default` → `default`, `placeholder`, `options`),
+with property types mapped to field types (`string`/`text` → `text`,
+`integer`/`float` → `number`, `checkbox` → `checkbox`, `dropdown` →
+`dropdown`, `set` → `checkboxlist`). The block's own `fields:` always take
+precedence over fields derived from the component on key collision. If the
+component can't be resolved, a warning is logged and the block's own fields
+are used as-is.
+
 ## Using the `blocks` FormWidget
 
 In order to provide an interface for managing block-based content, this plugin provides the `blocks` FormWidget. This widget can be used in the backend as a form field to manage blocks.

--- a/classes/BlockManager.php
+++ b/classes/BlockManager.php
@@ -7,6 +7,7 @@ use Cms\Classes\Controller;
 use Cms\Classes\Theme;
 use Event;
 use File;
+use Log;
 use System\Classes\PluginManager;
 use Winter\Storm\Support\Traits\Singleton;
 use Winter\Storm\Support\Str;
@@ -98,7 +99,7 @@ class BlockManager
                 }
             }
 
-            $configs[pathinfo($block['fileName'])['filename']] = array_except(
+            $config = array_except(
                 $block->getAttributes(),
                 [
                     'fileName',
@@ -108,9 +109,89 @@ class BlockManager
                     'code',
                 ]
             );
+
+            $config = $this->resolveComponent($config);
+
+            $configs[pathinfo($block['fileName'])['filename']] = $config;
         }
 
         return $configs;
+    }
+
+    /**
+     * Resolves a `component:` key in a block config by merging the component's
+     * `defineProperties()` into the block's `fields:` as base definitions.
+     *
+     * A block may declare:
+     *
+     *     component: mfaGateway
+     *
+     * The component's `defineProperties()` entries are converted to block field
+     * definitions and merged as defaults; the block's own `fields:` always win.
+     *
+     * Property-to-field mapping:
+     *   title       → label
+     *   description → comment
+     *   type        → type (string → text, dropdown → dropdown, checkbox → checkbox)
+     *   default     → default
+     */
+    protected function resolveComponent(array $config): array
+    {
+        if (empty($config['component']) || !is_string($config['component'])) {
+            unset($config['component']);
+            return $config;
+        }
+
+        $componentName = $config['component'];
+        unset($config['component']);
+
+        try {
+            $class = \Cms\Classes\ComponentManager::instance()->resolve($componentName);
+            if (!$class) {
+                Log::warning("Winter.Blocks: component '{$componentName}' not found for block.");
+                return $config;
+            }
+
+            /** @var \Cms\Classes\ComponentBase $instance */
+            $instance = new $class();
+            $properties = method_exists($instance, 'defineProperties') ? $instance->defineProperties() : [];
+
+            // Map component type names to block/form field type names.
+            $typeMap = [
+                'string'   => 'text',
+                'text'     => 'text',
+                'integer'  => 'number',
+                'float'    => 'number',
+                'checkbox' => 'checkbox',
+                'dropdown' => 'dropdown',
+                'set'      => 'checkboxlist',
+            ];
+
+            $fromComponent = [];
+            foreach ($properties as $name => $def) {
+                $propType  = $def['type'] ?? 'string';
+                $fieldType = $typeMap[$propType] ?? 'text';
+                $field = [
+                    'label'   => $def['title']       ?? $name,
+                    'type'    => $fieldType,
+                ];
+                if (isset($def['default']))     $field['default'] = $def['default'];
+                if (!empty($def['description'])) $field['comment'] = $def['description'];
+                if (!empty($def['placeholder'])) $field['placeholder'] = $def['placeholder'];
+                if (!empty($def['options']))     $field['options'] = $def['options'];
+
+                $fromComponent[$name] = $field;
+            }
+
+            // Block's own fields win; component fields fill in the rest.
+            $ownFields = (isset($config['fields']) && is_array($config['fields'])) ? $config['fields'] : [];
+            $config['fields'] = array_replace($fromComponent, $ownFields);
+
+        } catch (\Throwable $e) {
+            Log::warning("Winter.Blocks: could not resolve component '{$componentName}': " . $e->getMessage());
+        }
+
+        return $config;
     }
 
     /**

--- a/tests/classes/BlockManagerTest.php
+++ b/tests/classes/BlockManagerTest.php
@@ -2,9 +2,11 @@
 
 namespace Winter\Blocks\Tests\Classes;
 
+use Cms\Classes\ComponentManager;
 use Cms\Classes\Theme;
 use System\Tests\Bootstrap\PluginTestCase;
 use Winter\Blocks\Classes\BlockManager;
+use Winter\Blocks\Tests\Fixtures\Components\TestComponent;
 use Winter\Storm\Filesystem\PathResolver;
 use Winter\Storm\Support\Facades\Config;
 use Winter\Storm\Support\Facades\Event;
@@ -33,6 +35,101 @@ class BlockManagerTest extends PluginTestCase
         $this->manager = BlockManager::instance();
         $this->fixturePath = dirname(__DIR__) . '/fixtures/blocks/';
         $this->pluginPath = dirname(dirname(__DIR__)) . '/blocks/';
+    }
+
+    /**
+     * Invokes the protected resolveComponent() on the manager instance.
+     */
+    protected function resolveComponent(array $config): array
+    {
+        $method = new \ReflectionMethod(BlockManager::class, 'resolveComponent');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->manager, $config);
+    }
+
+    /**
+     * @testdox merges a component's defineProperties() into fields, with the block's own fields winning
+     */
+    public function testComponentPropertiesAreMergedIntoFields()
+    {
+        ComponentManager::instance()->registerComponent(TestComponent::class, 'testcomponent');
+
+        $result = $this->resolveComponent([
+            'component' => 'testcomponent',
+            'fields' => [
+                'style' => [
+                    'label' => 'Style override',
+                    'type' => 'dropdown',
+                ],
+            ],
+        ]);
+
+        // The component key is stripped once resolved.
+        $this->assertArrayNotHasKey('component', $result);
+
+        // Fields derived from the component's properties are present.
+        $this->assertArrayHasKey('headline', $result['fields']);
+        $this->assertEquals('Headline', $result['fields']['headline']['label']);
+        $this->assertEquals('text', $result['fields']['headline']['type']);
+        $this->assertEquals('Hello world', $result['fields']['headline']['default']);
+
+        $this->assertArrayHasKey('featured', $result['fields']);
+        $this->assertEquals('checkbox', $result['fields']['featured']['type']);
+
+        // The block's own field definition for "style" wins over the component's.
+        $this->assertEquals('Style override', $result['fields']['style']['label']);
+        $this->assertEquals('dropdown', $result['fields']['style']['type']);
+    }
+
+    /**
+     * @testdox leaves the config untouched when no component key is present
+     */
+    public function testNoComponentKeyIsNoop()
+    {
+        $config = [
+            'fields' => [
+                'title' => ['label' => 'Title', 'type' => 'text'],
+            ],
+        ];
+
+        $this->assertEquals($config, $this->resolveComponent($config));
+    }
+
+    /**
+     * @testdox ignores an unresolvable component reference without throwing
+     */
+    public function testUnknownComponentIsIgnored()
+    {
+        $result = $this->resolveComponent([
+            'component' => 'does_not_exist_component',
+            'fields' => [
+                'title' => ['label' => 'Title', 'type' => 'text'],
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('component', $result);
+        $this->assertArrayHasKey('title', $result['fields']);
+        $this->assertCount(1, $result['fields']);
+    }
+
+    /**
+     * @testdox resolves a block file's `component:` key end-to-end through getConfigs()
+     */
+    public function testGetConfigsResolvesComponentKeyFromBlockFile()
+    {
+        ComponentManager::instance()->registerComponent(TestComponent::class, 'testcomponent');
+
+        $this->manager->registerBlock('with_component', $this->fixturePath . 'with_component.block');
+
+        $configs = $this->manager->getConfigs();
+
+        $this->assertArrayHasKey('with_component', $configs);
+        $this->assertArrayNotHasKey('component', $configs['with_component']);
+        $this->assertArrayHasKey('headline', $configs['with_component']['fields']);
+        $this->assertEquals('Hello world', $configs['with_component']['fields']['headline']['default']);
+        // Block's own field definition still wins.
+        $this->assertEquals('Style override', $configs['with_component']['fields']['style']['label']);
     }
 
     public function testCanRegisterBlocksDirectly()

--- a/tests/fixtures/blocks/with_component.block
+++ b/tests/fixtures/blocks/with_component.block
@@ -1,0 +1,10 @@
+name: With component
+description: Block that resolves its fields from a component
+icon: icon-square
+tags: ["content"]
+component: testcomponent
+fields:
+    style:
+        label: Style override
+        type: dropdown
+==

--- a/tests/fixtures/components/TestComponent.php
+++ b/tests/fixtures/components/TestComponent.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Winter\Blocks\Tests\Fixtures\Components;
+
+use Cms\Classes\ComponentBase;
+
+/**
+ * Fixture component used to test `component: key` resolution in
+ * BlockManager::resolveComponent().
+ */
+class TestComponent extends ComponentBase
+{
+    public function componentDetails()
+    {
+        return [
+            'name' => 'Test Component',
+            'description' => 'A component used for testing block config component resolution.',
+        ];
+    }
+
+    public function defineProperties()
+    {
+        return [
+            'headline' => [
+                'title' => 'Headline',
+                'description' => 'The headline to display.',
+                'type' => 'string',
+                'default' => 'Hello world',
+            ],
+            'style' => [
+                'title' => 'Style',
+                'type' => 'dropdown',
+                'options' => [
+                    'bold' => 'Bold',
+                    'italic' => 'Italic',
+                ],
+            ],
+            'featured' => [
+                'title' => 'Featured',
+                'type' => 'checkbox',
+                'default' => false,
+            ],
+        ];
+    }
+}

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,2 +1,4 @@
 '1.0.0':
     - 'First version of Winter.Blocks'
+'1.1.0':
+    - 'Add component: key support to block config resolution'


### PR DESCRIPTION
Split out of #68 (closed in favor of smaller, focused PRs).

## Summary
- A block can declare a top-level `component:` key to derive default fields from a CMS component's `defineProperties()`, instead of (or alongside) hand-written `fields:`.
- Component properties are converted to block fields (title → label, description → comment, default, placeholder, options), with property types mapped to field types.
- The block's own `fields:` always take precedence over fields derived from the component on key collision. If the component can't be resolved, a warning is logged and the block's own fields are used as-is.

See the README section "Deriving fields from a component" for usage.

## Test plan
- [x] New tests in `tests/classes/BlockManagerTest.php` covering property merge, override precedence, and unresolvable-component handling, plus an end-to-end test via a real `.block` file
- [x] Full plugin test suite passes (`php artisan winter:test -p Winter.Blocks`)